### PR TITLE
Fix i18next unused keys when using self defined translation components

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,28 +112,28 @@ Hint: If you want to use the `--unused` flag, you should provide `react-intl` or
 yarn i18n:check --locales translations/i18NextMessageExamples -s en-US -f i18next
 ```
 
-### --check, -c
+### --only, -o
 
-By default i18n-check will perform a validation against any **missing** and/or **invalid** keys. There are situations where only a specific check should run. By using the `-c` or `--check` option you can specify a specific check to run.
+By default i18n-check will perform a validation against any **missing** and/or **invalid** keys. There are situations where only a specific check should run. By using the `-o` or `--only` option you can specify a specific check to run.
 
 The available options are `missingKeys`, which will check against any missing keys in the target files and `invalidKeys` will check for invalid keys, where the target translations has a different type then the one defined in the source file.
 
 Check for missing keys:
 
 ```bash
-yarn i18n:check --locales translations/messageExamples -s en-US -c missingKeys
+yarn i18n:check --locales translations/messageExamples -s en-US -o missingKeys
 ```
 
 Check for invalid keys:
 
 ```bash
-yarn i18n:check --locales translations/messageExamples -s en-US -c invalidKeys
+yarn i18n:check --locales translations/messageExamples -s en-US -o invalidKeys
 ```
 
 Check for missing and invalid keys (which is the default):
 
 ```bash
-yarn i18n:check --locales translations/messageExamples -s en-US -c missingKeys,invalidKeys
+yarn i18n:check --locales translations/messageExamples -s en-US -o missingKeys,invalidKeys
 ```
 
 ### --unused, -u
@@ -159,6 +159,20 @@ Using the `-r` or `--reporter` option enables to override the standard error rep
 
 ```bash
 yarn i18n:check --locales translations/messageExamples -s en-US -r summary
+```
+
+### --parser-component-functions
+
+When using the `unused` option, there will be situations where the i18next-parser will not be able to find components that wrap a `Trans` component.The component names for i18next-parser to match should be provided via the `--parser-component-functions` option. By default `Trans` will always be matched and can be used to define additional names for matching.
+
+```bash
+yarn i18n:check --locales translations/i18NextMessageExamples -s en-US -f i18next
+-u src --parser-component-functions WrappedTransComponent
+```
+
+```bash
+yarn i18n:check --locales translations/i18NextMessageExamples -s en-US -f i18next
+-u src --parser-component-functions WrappedTransComponent AnotherWrappedTransComponent
 ```
 
 ### --exclude, -e
@@ -206,7 +220,7 @@ locales/
   de-de.json
 ```
 
-Use the `t` or `target` option to define the directory that should be checked for target files. With the `s` or `source` option you can specify the base/reference file to compare the target files against.
+Use the `-l` or `--locales` option to define the directory that should be checked for target files. With the `s` or `source` option you can specify the base/reference file to compare the target files against.
 
 ```bash
 yarn i18n:check --locales locales -s locales/en-us.json

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ yarn i18n:check --locales translations/messageExamples -s en-US -o invalidKeys
 Check for missing and invalid keys (which is the default):
 
 ```bash
-yarn i18n:check --locales translations/messageExamples -s en-US -o missingKeys,invalidKeys
+yarn i18n:check --locales translations/messageExamples -s en-US -o missingKeys invalidKeys
 ```
 
 ### --unused, -u
@@ -159,20 +159,6 @@ Using the `-r` or `--reporter` option enables to override the standard error rep
 
 ```bash
 yarn i18n:check --locales translations/messageExamples -s en-US -r summary
-```
-
-### --parser-component-functions
-
-When using the `unused` option, there will be situations where the i18next-parser will not be able to find components that wrap a `Trans` component.The component names for i18next-parser to match should be provided via the `--parser-component-functions` option. By default `Trans` will always be matched and can be used to define additional names for matching.
-
-```bash
-yarn i18n:check --locales translations/i18NextMessageExamples -s en-US -f i18next
--u src --parser-component-functions WrappedTransComponent
-```
-
-```bash
-yarn i18n:check --locales translations/i18NextMessageExamples -s en-US -f i18next
--u src --parser-component-functions WrappedTransComponent AnotherWrappedTransComponent
 ```
 
 ### --exclude, -e
@@ -205,6 +191,20 @@ yarn i18n:check --locales translations/folderExamples -s en-US -e translations/f
 
 The `--exclude` option also accepts a mix of files and folders, which follows the same pattern as above, i.e.
 `-e translations/folderExamples/fr/* translations/messageExamples/it.json`
+
+### --parser-component-functions
+
+When using the `--unused` option, there will be situations where the i18next-parser will not be able to find components that wrap a `Trans` component.The component names for i18next-parser to match should be provided via the `--parser-component-functions` option. This option should onlybe used to define additional names for matching, a by default `Trans` will always be matched.
+
+```bash
+yarn i18n:check --locales translations/i18NextMessageExamples -s en-US -f i18next
+-u src --parser-component-functions WrappedTransComponent
+```
+
+```bash
+yarn i18n:check --locales translations/i18NextMessageExamples -s en-US -f i18next
+-u src --parser-component-functions WrappedTransComponent AnotherWrappedTransComponent
+```
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/lingualdev/i18n-check.git"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -305,7 +305,7 @@ No invalid translations found!
 
     it("should find unused keys for react-i18next applications", (done) => {
       exec(
-        "node dist/bin/index.js --source en --locales translations/codeExamples/reacti18next/locales -f i18next -u translations/codeExamples/reacti18next/src",
+        "node dist/bin/index.js --source en --locales translations/codeExamples/reacti18next/locales -f i18next -u translations/codeExamples/reacti18next/src --parser-component-functions WrappedTransComponent",
         (_error, stdout, _stderr) => {
           const result = stdout.split("Done")[0];
           expect(result).toEqual(`i18n translations checker

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -25,6 +25,10 @@ program
     "define the specific format: i18next or react-intl"
   )
   .option(
+    "-c, --check <checks...>",
+    "this option is deprecated - use -o or --only instead"
+  )
+  .option(
     "-o, --only <only...>",
     "define the specific checks you want to run: invalid, missing. By default the check will validate against missing and invalid keys, i.e. --only invalidKeys,missingKeys"
   )
@@ -42,12 +46,21 @@ program
   )
   .option(
     "--parser-component-functions <components...>",
-    "A list of components to parse"
+    "a list of component names to parse when using the --unused option"
   )
   .parse();
 
 const getCheckOptions = (): Context[] => {
-  const checkOption = program.getOptionValue("only");
+  const checkOption =
+    program.getOptionValue("only") || program.getOptionValue("check");
+
+  if (program.getOptionValue("check")) {
+    console.log(
+      chalk.yellow(
+        "The --check option has been deprecated, use the --only option instead."
+      )
+    );
+  }
 
   if (!checkOption) {
     return ["invalidKeys", "missingKeys"];

--- a/translations/codeExamples/reacti18next/locales/en/translation.json
+++ b/translations/codeExamples/reacti18next/locales/en/translation.json
@@ -18,5 +18,8 @@
     "audio": "An audio format",
     "ebook": "An e-book formt"
   },
-  "nonExistentKey": "Key does not exist"
+  "nonExistentKey": "Key does not exist",
+  "test": {
+    "one": "one"
+  }
 }

--- a/translations/codeExamples/reacti18next/locales/fr/translation.json
+++ b/translations/codeExamples/reacti18next/locales/fr/translation.json
@@ -18,5 +18,8 @@
     "audio": "An audio format",
     "ebook": "An e-book formt"
   },
-  "nonExistentKey": "Key does not exist"
+  "nonExistentKey": "Key does not exist",
+  "test": {
+    "one": "one"
+  }
 }

--- a/translations/codeExamples/reacti18next/src/App.tsx
+++ b/translations/codeExamples/reacti18next/src/App.tsx
@@ -3,6 +3,10 @@ import React from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Content } from "./Content";
 
+const WrappedTransComponent = (props) => {
+  return <Trans {...props} />;
+};
+
 export const I18NextExample = () => {
   const { t } = useTranslation();
 
@@ -27,6 +31,11 @@ export const I18NextExample = () => {
         Welcome <b>{{ userName }}</b>, you can check for more information{" "}
         <a href="some-link">here</a>!
       </Trans>
+
+      <WrappedTransComponent i18nKey="test.one">
+        Welcome <b>{{ userName }}</b>, you can check for more information{" "}
+        <a href="some-link">here</a>!
+      </WrappedTransComponent>
 
       <div>
         <Trans i18nKey="content.intro" />


### PR DESCRIPTION
Fixes `i18next` unused keys command when using self defined translation components. For example when a `Trans` component is wrapped in another component, the parser will skip checking for the key, which results in the key shown as not used.

```tsx
<WrappedTransComponent i18nKey="test.one">
  Welcome <b>{{ userName }}</b>, you can check for more information{" "}
  <a href="some-link">here</a>!
</WrappedTransComponent>
```

In that example the key `test.one` was identified as not used.

This change introduces the ` --parser-component-functions` to define all the additional component names that the i18next-parser should match.

Fixes #22 