### PR TITLE
Fix i18next unused keys/namespace combinations

### DIFF
--- a/translations/codeExamples/reacti18next/locales/en/translation.json
+++ b/translations/codeExamples/reacti18next/locales/en/translation.json
@@ -21,5 +21,15 @@
   "nonExistentKey": "Key does not exist",
   "test": {
     "one": "one"
+  },
+  "some": {
+    "deep": {
+      "nested": {
+        "key": "Some deep nested key"
+      }
+    }
+  },
+  "user": {
+    "one": "some id"
   }
 }

--- a/translations/codeExamples/reacti18next/locales/fr/translation.json
+++ b/translations/codeExamples/reacti18next/locales/fr/translation.json
@@ -22,13 +22,6 @@
   "test": {
     "one": "one"
   },
-  "account": {
-    "tabs": {
-      "positions": {
-        "table": { "footer": { "closeAll": { "modal": { "subtitle": "a" } } } }
-      }
-    }
-  },
   "some": {
     "deep": {
       "nested": {

--- a/translations/codeExamples/reacti18next/locales/fr/translation.json
+++ b/translations/codeExamples/reacti18next/locales/fr/translation.json
@@ -21,5 +21,22 @@
   "nonExistentKey": "Key does not exist",
   "test": {
     "one": "one"
+  },
+  "account": {
+    "tabs": {
+      "positions": {
+        "table": { "footer": { "closeAll": { "modal": { "subtitle": "a" } } } }
+      }
+    }
+  },
+  "some": {
+    "deep": {
+      "nested": {
+        "key": "Some deep nested key"
+      }
+    }
+  },
+  "user": {
+    "one": "some id"
   }
 }

--- a/translations/codeExamples/reacti18next/src/App.tsx
+++ b/translations/codeExamples/reacti18next/src/App.tsx
@@ -33,9 +33,23 @@ export const I18NextExample = () => {
       </Trans>
 
       <WrappedTransComponent i18nKey="test.one">
-        Welcome <b>{{ userName }}</b>, you can check for more information{" "}
+        Welcome <b>{userName}</b>, you can check for more information{" "}
         <a href="some-link">here</a>!
       </WrappedTransComponent>
+
+      <WrappedTransComponent i18nKey="user.one" ns="one">
+        Welcome <b>{user}</b>!
+      </WrappedTransComponent>
+
+      <WrappedTransComponent
+        i18nKey="some.deep.nested.key"
+        ns="two"
+        components={[
+          <>
+            <div />
+          </>,
+        ]}
+      />
 
       <div>
         <Trans i18nKey="content.intro" />


### PR DESCRIPTION
Updates the way the keys are retrieved from the i18next-parser by directly calling the internal parser. Prior to this change, not all keys would be collected when there were multiple namespaces in the code. With the introduction of this change, that issue is solved now, but this still neglects if the key is in a namespace or not. This namespace to key validation will be solved in an upcoming PR.