### PR TITLE
Skip any parsed entries containing returnObjects

### DIFF
--- a/translations/codeExamples/reacti18next/locales/en/translation.json
+++ b/translations/codeExamples/reacti18next/locales/en/translation.json
@@ -31,5 +31,16 @@
   },
   "user": {
     "one": "some id"
+  },
+  "returnObjectLike": {
+    "one": "1",
+    "two": "2",
+    "three": "3",
+    "four": "4",
+    "five": "5",
+    "six": "6",
+    "seven": "7",
+    "eight": "8",
+    "nine": "9"
   }
 }

--- a/translations/codeExamples/reacti18next/locales/fr/translation.json
+++ b/translations/codeExamples/reacti18next/locales/fr/translation.json
@@ -31,5 +31,16 @@
   },
   "user": {
     "one": "some id"
+  },
+  "returnObjectLike": {
+    "one": "1",
+    "two": "2",
+    "three": "3",
+    "four": "4",
+    "five": "5",
+    "six": "6",
+    "seven": "7",
+    "eight": "8",
+    "nine": "9"
   }
 }

--- a/translations/codeExamples/reacti18next/src/App.tsx
+++ b/translations/codeExamples/reacti18next/src/App.tsx
@@ -12,6 +12,10 @@ export const I18NextExample = () => {
 
   const userName = "User One";
 
+  const returnObjectLike = t("returnObjectLike", { returnObjects: true });
+
+  const resolution = returnObjectLike["one"];
+
   return (
     <p className="example">
       <p>


### PR DESCRIPTION
There are i18next translations that can be called dynamically via setting the `returnObjects` option to true.

```ts
const returnObjectLike = t("returnObjectLike", { returnObjects: true });
```

In this case an array of entries is returned, and then dynamically selected at runtime.

```ts
const resolution = returnObjectLike[someDynamicKey];
```

To prevent these keys from being flagged as unused, they will be skipped from the unused keys check.

Solves #26 