### PR TITLE
Fix plural key comparison error

### DIFF
--- a/src/utils/findInvalidTranslations.test.ts
+++ b/src/utils/findInvalidTranslations.test.ts
@@ -75,4 +75,20 @@ describe("findInvalidTranslations", () => {
       fr: ["message.text-format"],
     });
   });
+
+  it("shouldn't fail if keys differ", () => {
+    expect(
+      findInvalidTranslations(
+        sourceFile,
+        {
+            de: {
+            ...secondaryFile,
+            "message.plural": "{count, plural, other {# artículos}}",
+          }
+        }
+      )
+    ).toEqual({
+      de: ["message.plural", "multipleVariables"]
+    });
+  });
 });

--- a/src/utils/findInvalidTranslations.ts
+++ b/src/utils/findInvalidTranslations.ts
@@ -100,7 +100,7 @@ export const hasDiff = (
       (isPluralElement(formatElementA) && isPluralElement(formatElementB))
     ) {
       const optionsA = Object.keys(formatElementA.options).sort();
-      const optionsB = Object.keys(formatElementA.options).sort();
+      const optionsB = Object.keys(formatElementB.options).sort();
 
       if (optionsA.join("-") !== optionsB.join("-")) {
         return true;


### PR DESCRIPTION
Whoops! Looks like there's a typo here. It causes an error in trying to compare locales that have different plural keys.