### PR TITLE
Introduce undefined keys check

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ yarn i18n:check --locales translations/messageExamples -s en-US -o missingKeys i
 
 ### --unused, -u
 
-This feature is currently only supported for `react-intl` and `i18next` based React applications and is useful when you need to know which keys exist in your translation files but not in your codebase. Via the `-u` or `--unused` option you provide a source path to the code, which will be parsed to find all unused keys in the primary target language.
+This feature is currently only supported for `react-intl` and `i18next` based React applications and is useful when you need to know which keys exist in your translation files but not in your codebase. Additionally an inverse check is run to find any keys that exist in the codebase but not in the translation files.
+
+Via the `-u` or `--unused` option you provide a source path to the code, which will be parsed to find all unused as well as undefined keys in the primary target language.
 
 It is important to note that you must also provide the `-f` or `--format` option with `react-intl` or `i18next` as value. See the [`format` section](#--format) for more information.
 

--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -303,7 +303,7 @@ No invalid translations found!
       );
     });
 
-    it("should find unused keys for react-i18next applications", (done) => {
+    it("should find unused and undefined keys for react-i18next applications", (done) => {
       exec(
         "node dist/bin/index.js --source en --locales translations/codeExamples/reacti18next/locales -f i18next -u translations/codeExamples/reacti18next/src --parser-component-functions WrappedTransComponent",
         (_error, stdout, _stderr) => {
@@ -323,6 +323,47 @@ Found unused keys!
 │  translations/codeExamples/reacti18next/locales/en/translation.json  │  format.ebook    │
 │  translations/codeExamples/reacti18next/locales/en/translation.json  │  nonExistentKey  │
 └──────────────────────────────────────────────────────────────────────┴──────────────────┘
+
+Found undefined keys!
+┌──────────────────────────────────────────────────────┬────────────────────────────────┐
+│ file                                                 │ key                            │
+├──────────────────────────────────────────────────────┼────────────────────────────────┤
+│  translations/codeExamples/reacti18next/src/App.tsx  │  some.key.that.is.not.defined  │
+└──────────────────────────────────────────────────────┴────────────────────────────────┘
+
+`);
+          done();
+        }
+      );
+    });
+
+    it("should find unused and undefined keys for react-intl applications", (done) => {
+      exec(
+        " node dist/bin/index.js --source en-US --locales translations/codeExamples/react-intl/locales -f react-intl -u translations/codeExamples/react-intl/src",
+        (_error, stdout, _stderr) => {
+          const result = stdout.split("Done")[0];
+          expect(result).toEqual(`i18n translations checker
+Source: en-US
+Selected format is: react-intl
+
+No missing keys found!
+
+No invalid translations found!
+
+Found unused keys!
+┌─────────────────────────────────────────────────────────────────┬─────────────────────────┐
+│ file                                                            │ key                     │
+├─────────────────────────────────────────────────────────────────┼─────────────────────────┤
+│  translations/codeExamples/react-intl/locales/en-US/one.json    │  message.number-format  │
+│  translations/codeExamples/react-intl/locales/en-US/three.json  │  multipleVariables      │
+└─────────────────────────────────────────────────────────────────┴─────────────────────────┘
+
+Found undefined keys!
+┌────────────────────────────────────────────────────┬────────────────────────────────┐
+│ file                                               │ key                            │
+├────────────────────────────────────────────────────┼────────────────────────────────┤
+│  translations/codeExamples/react-intl/src/App.tsx  │  some.key.that.is.not.defined  │
+└────────────────────────────────────────────────────┴────────────────────────────────┘
 
 `);
           done();

--- a/translations/codeExamples/react-intl/locales/de-DE/one.json
+++ b/translations/codeExamples/react-intl/locales/de-DE/one.json
@@ -1,0 +1,8 @@
+{
+  "message.simple": "A simple message.",
+  "message.argument": "Hi, {name}! 👋",
+  "message.plural": "{count, plural, one {# item} other {# items}}",
+  "message.select": "{gender, select, male {Mr} female {Mrs} other {User}}",
+  "message.text-format": "Hi, <b>John</b>!",
+  "message.number-format": "Formatted number: {num, number, ::K}"
+}

--- a/translations/codeExamples/react-intl/locales/de-DE/three.json
+++ b/translations/codeExamples/react-intl/locales/de-DE/three.json
@@ -1,0 +1,5 @@
+{
+  "multipleVariables": "Hi {user}, it is {today, date, medium} and tomorrow it is {tomorrow, date, medium}.",
+  "select": "You selected {choice, select, yes {Yea} no {Nay} other {Maybe}}",
+  "nested.select": "{done, select, no {There is more to it {count, number}.} other {Done.}}"
+}

--- a/translations/codeExamples/react-intl/locales/de-DE/two.json
+++ b/translations/codeExamples/react-intl/locales/de-DE/two.json
@@ -1,0 +1,6 @@
+{
+  "test.drive.one": "testing one",
+  "test.drive.two": "testing two",
+  "test.drive.three": "testing three",
+  "test.drive.four": "testing four"
+}

--- a/translations/codeExamples/react-intl/locales/en-US/one.json
+++ b/translations/codeExamples/react-intl/locales/en-US/one.json
@@ -1,0 +1,8 @@
+{
+  "message.simple": "A simple message.",
+  "message.argument": "Hi, {name}! 👋",
+  "message.plural": "{count, plural, one {# item} other {# items}}",
+  "message.select": "{gender, select, male {Mr} female {Mrs} other {User}}",
+  "message.text-format": "Hi, <b>John</b>!",
+  "message.number-format": "Formatted number: {num, number, ::K}"
+}

--- a/translations/codeExamples/react-intl/locales/en-US/three.json
+++ b/translations/codeExamples/react-intl/locales/en-US/three.json
@@ -1,0 +1,5 @@
+{
+  "multipleVariables": "Hi {user}, it is {today, date, medium} and tomorrow it is {tomorrow, date, medium}.",
+  "select": "You selected {choice, select, yes {Yea} no {Nay} other {Maybe}}",
+  "nested.select": "{done, select, no {There is more to it {count, number}.} other {Done.}}"
+}

--- a/translations/codeExamples/react-intl/locales/en-US/two.json
+++ b/translations/codeExamples/react-intl/locales/en-US/two.json
@@ -1,0 +1,6 @@
+{
+  "test.drive.one": "testing one",
+  "test.drive.two": "testing two",
+  "test.drive.three": "testing three",
+  "test.drive.four": "testing four"
+}

--- a/translations/codeExamples/react-intl/src/App.tsx
+++ b/translations/codeExamples/react-intl/src/App.tsx
@@ -1,0 +1,40 @@
+// @ts-nocheck
+import React from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { Content } from "./Content";
+
+export const ReactIntlExample = () => {
+  const intl = useIntl();
+
+  return (
+    <p className="example">
+      <p>
+        {intl.formatMessage({
+          id: "message.argument",
+          defaultMessage: "A fallback just in case",
+        })}
+      </p>
+
+      <FormattedMessage id="message.plural">
+        Welcome <b>{{ userName }}</b>, you can check for more information{" "}
+        <a href="some-link">here</a>!
+      </FormattedMessage>
+
+      <FormattedMessage id="select" />
+
+      <FormattedMessage id="message.select">
+        Welcome <b>{userName}</b>, you can check for more information{" "}
+        <a href="some-link">here</a>!
+      </FormattedMessage>
+
+      <FormattedMessage id="message.text-format">
+        Welcome <b>{user}</b>!
+      </FormattedMessage>
+
+      <FormattedMessage id="nested.select" />
+
+      <FormattedMessage id="some.key.that.is.not.defined" />
+      <Content />
+    </p>
+  );
+};

--- a/translations/codeExamples/react-intl/src/Content.tsx
+++ b/translations/codeExamples/react-intl/src/Content.tsx
@@ -1,0 +1,18 @@
+// @ts-nocheck
+import React from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+export const Content = () => {
+  const intl = useIntl();
+
+  return (
+    <p className="example">
+      <FormattedMessage id="test.drive.one" />
+      <FormattedMessage id="test.drive.two" />
+      <FormattedMessage id="test.drive.three" />
+      <FormattedMessage id="test.drive.four" />
+
+      {intl.formatMessage({ id: "message.simple" })}
+    </p>
+  );
+};

--- a/translations/codeExamples/reacti18next/src/App.tsx
+++ b/translations/codeExamples/reacti18next/src/App.tsx
@@ -27,6 +27,7 @@ export const I18NextExample = () => {
         {t("two", "Value two")}
         {t("three", "Value three")}
         {t("more", "More!")}
+        {t("some.key.that.is.not.defined", "Some key that is not defined!")}
       </p>
 
       <p>{t("testing.one", "Some default value")}</p>


### PR DESCRIPTION
Additional inverse check to the unused keys check, which checks if any keys are defined in the codebase but are missing in the locale files. The check compares against the primary language locale. The check runs together with the unused keys checks.


```bash
i18n translations checker
Source: en
Selected format is: i18next

No missing keys found!

No invalid translations found!

Found unused keys!
┌──────────────────────────────────────────────────────────────────────┬──────────────────┐
│ file                                                                 │ key              │
├──────────────────────────────────────────────────────────────────────┼──────────────────┤
│  translations/codeExamples/reacti18next/locales/en/translation.json  │  format.ebook    │
│  translations/codeExamples/reacti18next/locales/en/translation.json  │  nonExistentKey  │
└──────────────────────────────────────────────────────────────────────┴──────────────────┘

Found undefined keys!
┌──────────────────────────────────────────────────────┬────────────────────────────────┐
│ file                                                 │ key                            │
├──────────────────────────────────────────────────────┼────────────────────────────────┤
│  translations/codeExamples/reacti18next/src/App.tsx  │  some.key.that.is.not.defined  │
└──────────────────────────────────────────────────────┴────────────────────────────────┘


```



Resolves #33 