### PR TITLE
Introduce next-intl unused and undefined keys check

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,11 @@ yarn i18n:check --locales translations/messageExamples -s en-US -o missingKeys i
 
 ### --unused, -u
 
-This feature is currently only supported for `react-intl` and `i18next` based React applications and is useful when you need to know which keys exist in your translation files but not in your codebase. Additionally an inverse check is run to find any keys that exist in the codebase but not in the translation files.
+This feature is currently only supported for `react-intl` and `i18next` as well as `next-intl` (experimental at the moment) based React applications and is useful when you need to know which keys exist in your translation files but not in your codebase. Additionally an inverse check is run to find any keys that exist in the codebase but not in the translation files.
 
 Via the `-u` or `--unused` option you provide a source path to the code, which will be parsed to find all unused as well as undefined keys in the primary target language.
 
-It is important to note that you must also provide the `-f` or `--format` option with `react-intl` or `i18next` as value. See the [`format` section](#--format) for more information.
+It is important to note that you must also provide the `-f` or `--format` option with `react-intl`, `i18next` or `next-intl` as value. See the [`format` section](#--format) for more information.
 
 ```bash
 yarn i18n:check --locales translations/messageExamples -s en-US -u client/ -f react-intl
@@ -152,6 +152,12 @@ or
 
 ```bash
 yarn i18n:check --locales translations/messageExamples -s en-US -u client/ -f i18next
+```
+
+or
+
+```bash
+yarn i18n:check --locales translations/messageExamples -s en-US -u client/ -f next-intl
 ```
 
 ### --reporter, -r

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "tsc",
     "test": "jest src/ --testPathIgnorePatterns src/bin/*",
+    "testing": "jest",
     "test:cli": "tsc && jest src/bin/index.test.ts"
   },
   "files": [
@@ -24,7 +25,8 @@
     "commander": "^12.1.0",
     "glob": "^11.0.1",
     "i18next-parser": "^9.3.0",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "typescript": "^5.8.3"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
@@ -33,8 +35,7 @@
     "@types/vinyl": "^2.0.12",
     "braces": "^3.0.3",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.6",
-    "typescript": "^5.7.3"
+    "ts-jest": "^29.2.6"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "build": "tsc",
     "test": "jest src/ --testPathIgnorePatterns src/bin/*",
-    "testing": "jest",
     "test:cli": "tsc && jest src/bin/index.test.ts"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@formatjs/cli-lib':
         specifier: ^6.6.6
-        version: 6.6.6(ts-jest@29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.10))(typescript@5.7.3))
+        version: 6.6.6(ts-jest@29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.10))(typescript@5.8.3))
       '@formatjs/icu-messageformat-parser':
         specifier: ^2.11.0
         version: 2.11.0
@@ -29,6 +29,9 @@ importers:
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -50,10 +53,7 @@ importers:
         version: 29.7.0(@types/node@22.10.10)
       ts-jest:
         specifier: ^29.2.6
-        version: 29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.10))(typescript@5.7.3)
-      typescript:
-        specifier: ^5.7.3
-        version: 5.7.3
+        version: 29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.10))(typescript@5.8.3)
 
 packages:
 
@@ -1931,8 +1931,8 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2318,11 +2318,11 @@ snapshots:
   '@esbuild/win32-x64@0.25.0':
     optional: true
 
-  '@formatjs/cli-lib@6.6.6(ts-jest@29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.10))(typescript@5.7.3))':
+  '@formatjs/cli-lib@6.6.6(ts-jest@29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.10))(typescript@5.8.3))':
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.9.4
       '@formatjs/icu-skeleton-parser': 1.8.8
-      '@formatjs/ts-transformer': 3.13.23(ts-jest@29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.10))(typescript@5.7.3))
+      '@formatjs/ts-transformer': 3.13.23(ts-jest@29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.10))(typescript@5.8.3))
       '@types/estree': 1.0.6
       '@types/fs-extra': 11.0.4
       '@types/json-stable-stringify': 1.1.0
@@ -2334,7 +2334,7 @@ snapshots:
       json-stable-stringify: 1.2.1
       loud-rejection: 2.2.0
       tslib: 2.8.1
-      typescript: 5.7.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - ts-jest
 
@@ -2389,7 +2389,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@formatjs/ts-transformer@3.13.23(ts-jest@29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.10))(typescript@5.7.3))':
+  '@formatjs/ts-transformer@3.13.23(ts-jest@29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.10))(typescript@5.8.3))':
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.9.4
       '@types/json-stable-stringify': 1.1.0
@@ -2397,9 +2397,9 @@ snapshots:
       chalk: 4.1.2
       json-stable-stringify: 1.2.1
       tslib: 2.8.1
-      typescript: 5.7.3
+      typescript: 5.8.3
     optionalDependencies:
-      ts-jest: 29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.10))(typescript@5.7.3)
+      ts-jest: 29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.10))(typescript@5.8.3)
 
   '@gulpjs/to-absolute-glob@4.0.0':
     dependencies:
@@ -3330,22 +3330,22 @@ snapshots:
       esbuild: 0.25.0
       fs-extra: 11.3.0
       gulp-sort: 2.0.0
-      i18next: 24.2.2(typescript@5.7.3)
+      i18next: 24.2.2(typescript@5.8.3)
       js-yaml: 4.1.0
       lilconfig: 3.1.3
       rsvp: 4.8.5
       sort-keys: 5.1.0
-      typescript: 5.7.3
+      typescript: 5.8.3
       vinyl: 3.0.0
       vinyl-fs: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  i18next@24.2.2(typescript@5.7.3):
+  i18next@24.2.2(typescript@5.8.3):
     dependencies:
       '@babel/runtime': 7.26.9
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.3
 
   iconv-lite@0.6.3:
     dependencies:
@@ -4196,7 +4196,7 @@ snapshots:
     dependencies:
       streamx: 2.22.0
 
-  ts-jest@29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.10))(typescript@5.7.3):
+  ts-jest@29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.10))(typescript@5.8.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -4207,7 +4207,7 @@ snapshots:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.7.1
-      typescript: 5.7.3
+      typescript: 5.8.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.26.0
@@ -4221,7 +4221,7 @@ snapshots:
 
   type-fest@0.21.3: {}
 
-  typescript@5.7.3: {}
+  typescript@5.8.3: {}
 
   underscore.string@3.3.6:
     dependencies:

--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -339,7 +339,7 @@ Found undefined keys!
 
     it("should find unused and undefined keys for react-intl applications", (done) => {
       exec(
-        " node dist/bin/index.js --source en-US --locales translations/codeExamples/react-intl/locales -f react-intl -u translations/codeExamples/react-intl/src",
+        "node dist/bin/index.js --source en-US --locales translations/codeExamples/react-intl/locales -f react-intl -u translations/codeExamples/react-intl/src",
         (_error, stdout, _stderr) => {
           const result = stdout.split("Done")[0];
           expect(result).toEqual(`i18n translations checker
@@ -364,6 +364,40 @@ Found undefined keys!
 ├────────────────────────────────────────────────────┼────────────────────────────────┤
 │  translations/codeExamples/react-intl/src/App.tsx  │  some.key.that.is.not.defined  │
 └────────────────────────────────────────────────────┴────────────────────────────────┘
+
+`);
+          done();
+        }
+      );
+    });
+
+    it("should find unused and undefined keys for next-intl applications", (done) => {
+      exec(
+        "node dist/bin/index.js --source en --locales translations/codeExamples/next-intl/locales/ -f next-intl -u translations/codeExamples/next-intl/src",
+        (_error, stdout, _stderr) => {
+          const result = stdout.split("Done")[0];
+          expect(result).toEqual(`i18n translations checker
+Source: en
+Selected format is: next-intl
+
+No missing keys found!
+
+No invalid translations found!
+
+Found unused keys!
+┌───────────────────────────────────────────────────────────────────┬──────────────────┐
+│ file                                                              │ key              │
+├───────────────────────────────────────────────────────────────────┼──────────────────┤
+│  translations/codeExamples/next-intl/locales/en/translation.json  │  message.plural  │
+│  translations/codeExamples/next-intl/locales/en/translation.json  │  notUsedKey      │
+└───────────────────────────────────────────────────────────────────┴──────────────────┘
+
+Found undefined keys!
+┌─────────────────────────────────────────────────────┬──────────────────┐
+│ file                                                │ key              │
+├─────────────────────────────────────────────────────┼──────────────────┤
+│  translations/codeExamples/next-intl/src/Basic.tsx  │  message.select  │
+└─────────────────────────────────────────────────────┴──────────────────┘
 
 `);
           done();

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -22,7 +22,7 @@ program
   .option("-s, --source <locale>", "the source locale to validate against")
   .option(
     "-f, --format <type>",
-    "define the specific format: i18next or react-intl"
+    "define the specific format: i18next, react-intl or next-intl"
   )
   .option(
     "-c, --check <checks...>",

--- a/src/utils/nextIntlSrcParser.test.ts
+++ b/src/utils/nextIntlSrcParser.test.ts
@@ -1,0 +1,312 @@
+import { count } from "node:console";
+import { extract } from "./nextIntlSrcParser";
+import path from "node:path";
+
+const srcPath = "./translations/codeExamples/next-intl/src/";
+
+const basicFile = path.join(srcPath, "Basic.tsx");
+const counterFile = path.join(srcPath, "Counter.tsx");
+const clientCounterFile = path.join(srcPath, "ClientCounter.tsx");
+const nestedExampleFile = path.join(srcPath, "NestedExample.tsx");
+const asyncExampleFile = path.join(srcPath, "AsyncExample.tsx");
+const dynamicKeysExamplFile = path.join(srcPath, "DynamicKeysExample.tsx");
+
+describe("nextIntlSrcParser", () => {
+  it("should find all the translation keys", () => {
+    const keys = extract([basicFile, counterFile, clientCounterFile]);
+
+    expect(keys).toEqual([
+      {
+        key: "ClientCounter2.increment",
+        meta: {
+          file: clientCounterFile,
+        },
+      },
+      {
+        key: "ClientCounter2.count",
+        meta: {
+          file: clientCounterFile,
+        },
+      },
+      {
+        key: "ClientCounter.increment",
+        meta: {
+          file: clientCounterFile,
+        },
+      },
+      {
+        key: "ClientCounter.count",
+        meta: {
+          file: clientCounterFile,
+        },
+      },
+      {
+        key: "Counter.increment",
+        meta: {
+          file: counterFile,
+        },
+      },
+      {
+        key: "Counter.count",
+        meta: {
+          file: counterFile,
+        },
+      },
+      {
+        key: "testKeyWithoutNamespace",
+        meta: {
+          file: basicFile,
+        },
+      },
+      {
+        key: "message.argument",
+        meta: {
+          file: basicFile,
+        },
+      },
+      {
+        key: "message.select",
+        meta: {
+          file: basicFile,
+        },
+      },
+      {
+        key: "message.simple",
+        meta: {
+          file: basicFile,
+        },
+      },
+      {
+        key: "Navigation.news",
+        meta: {
+          file: basicFile,
+        },
+      },
+      {
+        key: "Navigation.nested",
+        meta: {
+          file: basicFile,
+        },
+      },
+      {
+        key: "Navigation.about",
+        meta: {
+          file: basicFile,
+        },
+      },
+      {
+        key: "Navigation.client",
+        meta: {
+          file: basicFile,
+        },
+      },
+      {
+        key: "Navigation.home",
+        meta: {
+          file: basicFile,
+        },
+      },
+    ]);
+  });
+
+  it("should find all the nested translation keys", () => {
+    const keys = extract([nestedExampleFile]);
+
+    expect(keys).toEqual([
+      {
+        key: "nested.three.htmlKey",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/NestedExample.tsx",
+        },
+      },
+      {
+        key: "nested.three.markupKey",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/NestedExample.tsx",
+        },
+      },
+      {
+        key: "nested.three.richTextKey",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/NestedExample.tsx",
+        },
+      },
+      {
+        key: "nested.three.hasKeyCheck",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/NestedExample.tsx",
+        },
+      },
+      {
+        key: "nested.three.basicKey",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/NestedExample.tsx",
+        },
+      },
+      {
+        key: "deepNested.level1.one",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/NestedExample.tsx",
+        },
+      },
+      {
+        key: "deepNested.level2.two",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/NestedExample.tsx",
+        },
+      },
+      {
+        key: "deepNested.level3.three",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/NestedExample.tsx",
+        },
+      },
+      {
+        key: "deepNested.level4.four",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/NestedExample.tsx",
+        },
+      },
+      {
+        key: "nested.two.regularKey",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/NestedExample.tsx",
+        },
+      },
+      {
+        key: "nested.two.nestedKey",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/NestedExample.tsx",
+        },
+      },
+      {
+        key: "nested.nested.two.nestedTwoKey",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/NestedExample.tsx",
+        },
+      },
+      {
+        key: "nested.one.regularKey",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/NestedExample.tsx",
+        },
+      },
+      {
+        key: "nested.one.nestedKey",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/NestedExample.tsx",
+        },
+      },
+    ]);
+  });
+
+  it("should find all the async translation keys", () => {
+    const keys = extract([asyncExampleFile]);
+
+    expect(keys).toEqual([
+      {
+        key: "async.two.title",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/AsyncExample.tsx",
+        },
+      },
+      {
+        key: "Async.title",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/AsyncExample.tsx",
+        },
+      },
+    ]);
+  });
+
+  it("should find all dynamic keys defined as comments", () => {
+    const keys = extract([dynamicKeysExamplFile]);
+
+    expect(keys).toEqual([
+      {
+        key: "dynamic.three.value",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/DynamicKeysExample.tsx",
+        },
+      },
+      {
+        key: "dynamic.three.title",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/DynamicKeysExample.tsx",
+        },
+      },
+      {
+        key: "dynamic.two.value",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/DynamicKeysExample.tsx",
+        },
+      },
+      {
+        key: "dynamic.two.title",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/DynamicKeysExample.tsx",
+        },
+      },
+      {
+        key: "dynamic.one.value",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/DynamicKeysExample.tsx",
+        },
+      },
+      {
+        key: "dynamic.one.title",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/DynamicKeysExample.tsx",
+        },
+      },
+      {
+        key: "dynamic.four.four",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/DynamicKeysExample.tsx",
+        },
+      },
+      {
+        key: "dynamic.four.three",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/DynamicKeysExample.tsx",
+        },
+      },
+      {
+        key: "dynamic.four.two",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/DynamicKeysExample.tsx",
+        },
+      },
+      {
+        key: "dynamic.four.one",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/DynamicKeysExample.tsx",
+        },
+      },
+      {
+        key: "dynamic.four.nameFour",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/DynamicKeysExample.tsx",
+        },
+      },
+      {
+        key: "dynamic.four.nameThree",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/DynamicKeysExample.tsx",
+        },
+      },
+      {
+        key: "dynamic.four.nameTwo",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/DynamicKeysExample.tsx",
+        },
+      },
+      {
+        key: "dynamic.four.nameOne",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/DynamicKeysExample.tsx",
+        },
+      },
+    ]);
+  });
+});

--- a/src/utils/nextIntlSrcParser.ts
+++ b/src/utils/nextIntlSrcParser.ts
@@ -1,0 +1,201 @@
+import fs from "node:fs";
+import * as ts from "typescript";
+
+const USE_TRANSLATIONS = "useTranslations";
+const GET_TRANSLATIONS = "getTranslations";
+const COMMENT_CONTAINS_STATIC_KEY_REGEX = /t\((["'])(.*?[^\\])(["'])\)/;
+
+export const extract = (filesPaths: string[]) => {
+  return filesPaths.flatMap(getKeys).sort((a, b) => {
+    return a > b ? 1 : -1;
+  });
+};
+
+const getKeys = (path: string) => {
+  const content = fs.readFileSync(path, "utf-8");
+  const sourceFile = ts.createSourceFile(
+    path,
+    content,
+    ts.ScriptTarget.Latest,
+    true
+  );
+
+  const foundKeys: { key: string; meta: { file: string } }[] = [];
+  let namespaces: string[] = [];
+  let variable = "t";
+
+  const getCurrentNamespace = () => {
+    if (namespaces.length > 0) {
+      return namespaces[namespaces.length - 1];
+    }
+    return null;
+  };
+
+  const pushNamespace = (name: string) => {
+    namespaces.push(name);
+  };
+
+  const removeNamespace = () => {
+    if (namespaces.length > 0) {
+      namespaces.pop();
+    }
+  };
+
+  const visit = (node: ts.Node) => {
+    let key: string | null = null;
+    let current = namespaces.length;
+
+    if (node === undefined) {
+      return;
+    }
+
+    if (ts.isVariableDeclaration(node)) {
+      if (node.initializer && ts.isCallExpression(node.initializer)) {
+        if (ts.isIdentifier(node.initializer.expression)) {
+          // Search for `useTranslations` calls and extract the namespace
+          // Additionally check for assigned variable name, as it might differ
+          // from the default `t`, i.e.: const other = useTranslations("namespace1");
+          if (node.initializer.expression.text === USE_TRANSLATIONS) {
+            const [argument] = node.initializer.arguments;
+            if (argument && ts.isStringLiteral(argument)) {
+              pushNamespace(argument.text);
+            } else if (argument === undefined) {
+              pushNamespace("");
+            }
+            if (ts.isIdentifier(node.name)) {
+              variable = node.name.text;
+            }
+          }
+        }
+      }
+
+      // Search for `getTranslations` calls and extract the namespace
+      // There are two different ways `getTranslations` can be used:
+      //
+      // import {getTranslations} from 'next-intl/server';
+      // const t = await getTranslations(namespace?);
+      // const t = await getTranslations({locale, namespace});
+      //
+      // Additionally check for assigned variable name, as it might differ
+      // from the default `t`, i.e.: const other = getTranslations("namespace1");
+      // Simplified usage in async components
+      if (node.initializer && ts.isAwaitExpression(node.initializer)) {
+        if (
+          ts.isCallExpression(node.initializer.expression) &&
+          ts.isIdentifier(node.initializer.expression.expression)
+        ) {
+          if (
+            node.initializer.expression.expression.text === GET_TRANSLATIONS
+          ) {
+            const [argument] = node.initializer.expression.arguments;
+            if (argument && ts.isObjectLiteralExpression(argument)) {
+              argument.properties.forEach((property) => {
+                if (
+                  property &&
+                  ts.isPropertyAssignment(property) &&
+                  property.name &&
+                  ts.isIdentifier(property.name) &&
+                  property.name.text === "namespace" &&
+                  ts.isStringLiteral(property.initializer)
+                ) {
+                  pushNamespace(property.initializer.text);
+                }
+              });
+            } else if (argument && ts.isStringLiteral(argument)) {
+              pushNamespace(argument.text);
+            } else if (argument === undefined) {
+              pushNamespace("");
+            }
+
+            if (ts.isIdentifier(node.name)) {
+              variable = node.name.text;
+            }
+          }
+        }
+      }
+    }
+
+    // Search for `t()` calls
+    if (
+      getCurrentNamespace() !== null &&
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression)
+    ) {
+      const expressionName = node.expression.text;
+      if (expressionName === variable) {
+        const [argument] = node.arguments;
+        if (argument && ts.isStringLiteral(argument)) {
+          key = argument.text;
+        }
+      }
+    }
+
+    // Search for `t.*()` calls, i.e. t.html() or t.rich()
+    if (
+      getCurrentNamespace() !== null &&
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      ts.isIdentifier(node.expression.expression)
+    ) {
+      const expressionName = node.expression.expression.text;
+      if (expressionName === variable) {
+        const [argument] = node.arguments;
+        if (argument && ts.isStringLiteral(argument)) {
+          key = argument.text;
+        }
+      }
+    }
+
+    if (key) {
+      const namespace = getCurrentNamespace();
+      foundKeys.push({
+        key: namespace ? `${namespace}.${key}` : key,
+        meta: { file: path },
+      });
+    }
+
+    // Search for single-line comments that contain the static values of a dynamic key
+    // Example:
+    // const someKeys = messages[selectedOption];
+    // Define as a single-line comment all the possible static keys for that dynamic key
+    // t('some.static.key.we.want.to.extract');
+    // t('some.other.key.we.want.to.extract.without.semicolons')
+    const commentRanges = ts.getLeadingCommentRanges(
+      sourceFile.getFullText(),
+      node.getFullStart()
+    );
+
+    if (commentRanges?.length && commentRanges.length > 0) {
+      commentRanges.forEach((range) => {
+        const comment = sourceFile.getFullText().slice(range.pos, range.end);
+        // parse the string and check if it includes the following format:
+        // t('someString')
+        const hasStaticKeyComment =
+          COMMENT_CONTAINS_STATIC_KEY_REGEX.test(comment);
+
+        if (hasStaticKeyComment) {
+          // capture the string comment
+          const commentKey =
+            COMMENT_CONTAINS_STATIC_KEY_REGEX.exec(comment)?.[2];
+          if (commentKey) {
+            const namespace = getCurrentNamespace();
+            foundKeys.push({
+              key: namespace ? `${namespace}.${commentKey}` : commentKey,
+              meta: { file: path },
+            });
+          }
+        }
+      });
+    }
+
+    ts.forEachChild(node, visit);
+
+    if (ts.isFunctionLike(node) && namespaces.length > current) {
+      removeNamespace();
+    }
+  };
+
+  ts.forEachChild(sourceFile, visit);
+
+  return foundKeys;
+};

--- a/translations/codeExamples/next-intl/locales/en/translation.json
+++ b/translations/codeExamples/next-intl/locales/en/translation.json
@@ -1,0 +1,94 @@
+{
+  "message.simple": "A simple message.",
+  "message.argument": "Hi, {name}! 👋",
+  "message.plural": "{count, plural, one {# item} other {# items}}",
+  "Navigation": {
+    "news": "news",
+    "nested": "nested",
+    "about": "about",
+    "client": "client",
+    "home": "home"
+  },
+  "dynamic": {
+    "one": {
+      "title": "title",
+      "value": "value"
+    },
+    "two": {
+      "title": "title",
+      "value": "value"
+    },
+    "three": {
+      "title": "title",
+      "value": "three"
+    },
+    "four": {
+      "one": "one",
+      "two": "two",
+      "three": "three",
+      "four": "four",
+      "nameOne": "nameOne",
+      "nameTwo": "nameTwo",
+      "nameThree": "nameThree",
+      "nameFour": "nameFour"
+    }
+  },
+  "ClientCounter": {
+    "count": "Current count: {count}",
+    "increment": "Increment"
+  },
+  "ClientCounter2": {
+    "count": "Current count: {count}",
+    "increment": "Increment"
+  },
+  "Counter": {
+    "count": "Current count:",
+    "increment": "Increment"
+  },
+  "nested": {
+    "one": {
+      "regularKey": "regularKey",
+      "nestedKey": "nestedKey"
+    },
+    "two": {
+      "regularKey": "regularKey",
+      "nestedKey": "nestedKey"
+    },
+    "three": {
+      "basicKey": "basicKey",
+      "htmlKey": "htmlKey",
+      "richTextKey": "richTextKey",
+      "markupKey": "markupKey",
+      "hasKeyCheck": "hasKeyCheck"
+    },
+    "nested": {
+      "two": {
+        "nestedTwoKey": "nestedTwoKey"
+      }
+    }
+  },
+  "async": {
+    "two": {
+      "title": "title"
+    }
+  },
+  "Async": {
+    "title": "title"
+  },
+  "testKeyWithoutNamespace": "testKeyWithoutNamespace",
+  "notUsedKey": "notUsedKey",
+  "deepNested": {
+    "level1": {
+      "one": "one"
+    },
+    "level2": {
+      "two": "two"
+    },
+    "level3": {
+      "three": "three"
+    },
+    "level4": {
+      "four": "four"
+    }
+  }
+}

--- a/translations/codeExamples/next-intl/locales/fr/translation.json
+++ b/translations/codeExamples/next-intl/locales/fr/translation.json
@@ -1,0 +1,94 @@
+{
+  "message.simple": "A simple message.",
+  "message.argument": "Hi, {name}! 👋",
+  "message.plural": "{count, plural, one {# item} other {# items}}",
+  "Navigation": {
+    "news": "news",
+    "nested": "nested",
+    "about": "about",
+    "client": "client",
+    "home": "home"
+  },
+  "dynamic": {
+    "one": {
+      "title": "title",
+      "value": "value"
+    },
+    "two": {
+      "title": "title",
+      "value": "value"
+    },
+    "three": {
+      "title": "title",
+      "value": "three"
+    },
+    "four": {
+      "one": "one",
+      "two": "two",
+      "three": "three",
+      "four": "four",
+      "nameOne": "nameOne",
+      "nameTwo": "nameTwo",
+      "nameThree": "nameThree",
+      "nameFour": "nameFour"
+    }
+  },
+  "ClientCounter": {
+    "count": "Current count: {count}",
+    "increment": "Increment"
+  },
+  "ClientCounter2": {
+    "count": "Current count: {count}",
+    "increment": "Increment"
+  },
+  "Counter": {
+    "count": "Current count:",
+    "increment": "Increment"
+  },
+  "nested": {
+    "one": {
+      "regularKey": "regularKey",
+      "nestedKey": "nestedKey"
+    },
+    "two": {
+      "regularKey": "regularKey",
+      "nestedKey": "nestedKey"
+    },
+    "three": {
+      "basicKey": "basicKey",
+      "htmlKey": "htmlKey",
+      "richTextKey": "richTextKey",
+      "markupKey": "markupKey",
+      "hasKeyCheck": "hasKeyCheck"
+    },
+    "nested": {
+      "two": {
+        "nestedTwoKey": "nestedTwoKey"
+      }
+    }
+  },
+  "async": {
+    "two": {
+      "title": "title"
+    }
+  },
+  "Async": {
+    "title": "title"
+  },
+  "testKeyWithoutNamespace": "testKeyWithoutNamespace",
+  "notUsedKey": "notUsedKey",
+  "deepNested": {
+    "level1": {
+      "one": "one"
+    },
+    "level2": {
+      "two": "two"
+    },
+    "level3": {
+      "three": "three"
+    },
+    "level4": {
+      "four": "four"
+    }
+  }
+}

--- a/translations/codeExamples/next-intl/src/AsyncExample.tsx
+++ b/translations/codeExamples/next-intl/src/AsyncExample.tsx
@@ -1,0 +1,21 @@
+// @ts-nocheck
+import { getTranslations } from "next-intl/server";
+
+export default async function AsyncExampleOne() {
+  const t = await getTranslations("Async");
+  return <h1>{t("title")}</h1>;
+}
+
+export default async function AsyncExampleTwo() {
+  const user = await fetchUser();
+  const t = await getTranslations({
+    locale: "en",
+    namespace: "async.two",
+  });
+
+  return (
+    <PageLayout title={t("title", { username: user.name })}>
+      <UserDetails user={user} />
+    </PageLayout>
+  );
+}

--- a/translations/codeExamples/next-intl/src/Basic.tsx
+++ b/translations/codeExamples/next-intl/src/Basic.tsx
@@ -1,0 +1,43 @@
+// @ts-nocheck
+import { useTranslations } from "next-intl";
+import NavigationLink from "./NavigationLink";
+
+export default function NavigationExample() {
+  const t = useTranslations("Navigation");
+
+  return (
+    <nav>
+      <NavigationLink href="/">{t("home")}</NavigationLink>
+      <NavigationLink href="/client">{t("client")}</NavigationLink>
+      <NavigationLink href="/about">{t("about")}</NavigationLink>
+      <NavigationLink href="/nested">{t("nested")}</NavigationLink>
+      <NavigationLink href="/news">{t("news")}</NavigationLink>
+    </nav>
+  );
+}
+
+const BasicMessageComponent = () => {
+  const t = useTranslations("message");
+
+  return (
+    <div>
+      <div>{t("simple")}</div>
+      <div>{t("select")}</div>
+      <div>{t("argument")}</div>
+    </div>
+  );
+};
+
+export const NoNamespaceComponent = () => {
+  // no namespace defined
+  const t = useTranslations();
+
+  return <div>{t("testKeyWithoutNamespace")}</div>;
+};
+
+export const NonUseTranslationsUsageOfT = () => {
+  // no namespace defined
+  const t = useOtherHook();
+
+  return <div>{t("This should not be extraced")}</div>;
+};

--- a/translations/codeExamples/next-intl/src/ClientCounter.tsx
+++ b/translations/codeExamples/next-intl/src/ClientCounter.tsx
@@ -1,0 +1,41 @@
+// @ts-nocheck
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+
+export default function ClientCounterOne() {
+  const t = useTranslations("ClientCounter");
+  const [count, setCount] = useState(0);
+
+  function onIncrement() {
+    setCount(count + 1);
+  }
+
+  return (
+    <div data-testid="MessagesOnClientCounter">
+      <p>{t("count", { count: String(count) })}</p>
+      <button onClick={onIncrement} type="button">
+        {t("increment")}
+      </button>
+    </div>
+  );
+}
+
+export default function ClientCounterTwo() {
+  const differentNameForT = useTranslations("ClientCounter2");
+  const [count, setCount] = useState(0);
+
+  function onIncrement() {
+    setCount(count + 1);
+  }
+
+  return (
+    <div data-testid="MessagesOnClientCounter">
+      <p>{differentNameForT("count", { count: String(count) })}</p>
+      <button onClick={onIncrement} type="button">
+        {differentNameForT("increment")}
+      </button>
+    </div>
+  );
+}

--- a/translations/codeExamples/next-intl/src/Counter.tsx
+++ b/translations/codeExamples/next-intl/src/Counter.tsx
@@ -1,0 +1,16 @@
+// @ts-nocheck
+import { useTranslations } from "next-intl";
+import ClientCounter from "./ClientCounterExample";
+
+export default function Counter() {
+  const t = useTranslations("Counter");
+
+  return (
+    <ClientCounter
+      messages={{
+        count: t("count"),
+        increment: t("increment"),
+      }}
+    />
+  );
+}

--- a/translations/codeExamples/next-intl/src/DynamicKeysExample.tsx
+++ b/translations/codeExamples/next-intl/src/DynamicKeysExample.tsx
@@ -1,0 +1,57 @@
+// @ts-nocheck
+import { useTranslations } from "next-intl";
+
+const DynamicKeysExample = () => {
+  const t = useTranslations("dynamic.four");
+  return (
+    <div>
+      {["one", "two", "three", "four"].map((key) => {
+        let name = "";
+        switch (key) {
+          case "one":
+            name = t("nameOne");
+            break;
+          case "two":
+            name = t("nameTwo");
+            break;
+          case "three":
+            name = t("nameThree");
+            break;
+          case "nameFour":
+            name = t("nameFour");
+            break;
+          default:
+            name = "";
+        }
+        // Should be able to define static keys as comments:
+        // t('one');
+        // t('two');
+        // t('three');
+        // t('four');
+        return <div key={key}>{t(key)}</div>;
+      })}
+    </div>
+  );
+};
+
+function CompanyStatsExample() {
+  const t = useTranslations("dynamic");
+  const keys = ["one", "two", "three"] as const;
+
+  // t('one.title');
+  // t('one.value');
+  // t('two.title');
+  // t('two.value');
+  // t('three.title');
+  // t('three.value');
+  return (
+    <ul>
+      {keys.map((key) => (
+        <li key={key}>
+          <h2>{t(`${key}.title`)}</h2>
+          <p>{t(`${key}.value`)}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/translations/codeExamples/next-intl/src/NestedExample.tsx
+++ b/translations/codeExamples/next-intl/src/NestedExample.tsx
@@ -1,0 +1,57 @@
+// @ts-nocheck
+import { useTranslations } from "next-intl";
+
+const TestComponentOne = () => {
+  const t = useTranslations("nested.one");
+  const nested = () => {
+    return t("nestedKey");
+  };
+  return <div>{t("regularKey")}</div>;
+};
+
+function TestComponentTwo() {
+  const t = useTranslations("nested.two");
+  const nestedOne = () => {
+    const nestedTwo = () => {
+      const t = useTranslations("nested.nested.two");
+      return t("nestedTwoKey");
+    };
+    return t("nestedKey");
+  };
+  return <div>{t("regularKey")}</div>;
+}
+
+function TestComponentThree() {
+  const t = useTranslations("deepNested.level1");
+  const nestedOne = () => {
+    const t = useTranslations("deepNested.level2");
+    const nestedTwo = () => {
+      const t = useTranslations("deepNested.level3");
+      const nestedThree = () => {
+        const t = useTranslations("deepNested.level4");
+        return t("four");
+      };
+      return t("three");
+    };
+    return t("two");
+  };
+  return <div>{t("one")}</div>;
+}
+
+const TestComponentFour = () => {
+  const t = useTranslations("nested.three");
+
+  return (
+    <>
+      <div>{t("basicKey")}</div>
+      <div>{t.has("hasKeyCheck")}</div>
+      <div>{t.rich("richTextKey", { underline: "<u>underline</u>" })}</div>
+      <div>
+        {t.markup("markupKey", {
+          important: (chunks) => `<b>${chunks}</b>`,
+        })}
+      </div>
+      <div>{t.html("htmlKey", { test: "one" })}</div>
+    </>
+  );
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */


### PR DESCRIPTION
Introduces support for `next-intl`, checks for unused and undefined keys.

Resolves https://github.com/lingualdev/i18n-check/issues/37