### PR TITLE
Improve next-intl key extraction

### DIFF
--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -393,11 +393,21 @@ Found unused keys!
 └───────────────────────────────────────────────────────────────────┴──────────────────┘
 
 Found undefined keys!
-┌─────────────────────────────────────────────────────┬──────────────────┐
-│ file                                                │ key              │
-├─────────────────────────────────────────────────────┼──────────────────┤
-│  translations/codeExamples/next-intl/src/Basic.tsx  │  message.select  │
-└─────────────────────────────────────────────────────┴──────────────────┘
+┌──────────────────────────────────────────────────────────────────┬───────────────────┐
+│ file                                                             │ key               │
+├──────────────────────────────────────────────────────────────────┼───────────────────┤
+│  translations/codeExamples/next-intl/src/Basic.tsx               │  message.select   │
+│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  unknown.unknown  │
+│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  About.unknown    │
+│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  unknown          │
+│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  Test.title       │
+│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  title            │
+│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  unknown.unknown  │
+│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  About.unknown    │
+│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  unknown          │
+│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  Test.title       │
+│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  title            │
+└──────────────────────────────────────────────────────────────────┴───────────────────┘
 
 `);
           done();

--- a/src/utils/nextIntlSrcParser.test.ts
+++ b/src/utils/nextIntlSrcParser.test.ts
@@ -10,6 +10,7 @@ const clientCounterFile = path.join(srcPath, "ClientCounter.tsx");
 const nestedExampleFile = path.join(srcPath, "NestedExample.tsx");
 const asyncExampleFile = path.join(srcPath, "AsyncExample.tsx");
 const dynamicKeysExamplFile = path.join(srcPath, "DynamicKeysExample.tsx");
+const strictTypesExample = path.join(srcPath, "StrictTypesExample.tsx");
 
 describe("nextIntlSrcParser", () => {
   it("should find all the translation keys", () => {
@@ -305,6 +306,181 @@ describe("nextIntlSrcParser", () => {
         key: "dynamic.four.nameOne",
         meta: {
           file: "translations/codeExamples/next-intl/src/DynamicKeysExample.tsx",
+        },
+      },
+    ]);
+  });
+
+  it("should find all strict typed keys", () => {
+    const keys = extract([strictTypesExample]);
+
+    expect(keys).toEqual([
+      {
+        key: "unknown.unknown",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "About.unknown",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "unknown",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "Test.title",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "title",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "PageLayout.pageTitle",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "NotFound.title",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "Navigation.about",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "About.title",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "Navigation.about",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "About.lastUpdated",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "About.title",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "StrictTypes.nested.another.level",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "StrictTypes.nested.hello",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "unknown.unknown",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "About.unknown",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "unknown",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "Test.title",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "title",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "PageLayout.pageTitle",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "NotFound.title",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "Navigation.about",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "About.title",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "Navigation.about",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "About.lastUpdated",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "About.title",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "StrictTypes.nested.another.level",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
+        },
+      },
+      {
+        key: "StrictTypes.nested.hello",
+        meta: {
+          file: "translations/codeExamples/next-intl/src/StrictTypesExample.tsx",
         },
       },
     ]);

--- a/translations/codeExamples/next-intl/locales/en/translation.json
+++ b/translations/codeExamples/next-intl/locales/en/translation.json
@@ -90,5 +90,23 @@
     "level4": {
       "four": "four"
     }
+  },
+  "About": {
+    "title": "About",
+    "lastUpdated": "This example was updated {lastUpdatedRelative} ({lastUpdated, date, short})."
+  },
+  "NotFound": {
+    "title": "Sorry, this page could not be found."
+  },
+  "PageLayout": {
+    "pageTitle": "next-intl"
+  },
+  "StrictTypes": {
+    "nested": {
+      "hello": "Hello",
+      "another": {
+        "level": "Level"
+      }
+    }
   }
 }

--- a/translations/codeExamples/next-intl/locales/fr/translation.json
+++ b/translations/codeExamples/next-intl/locales/fr/translation.json
@@ -90,5 +90,23 @@
     "level4": {
       "four": "four"
     }
+  },
+  "About": {
+    "title": "About",
+    "lastUpdated": "This example was updated {lastUpdatedRelative} ({lastUpdated, date, short})."
+  },
+  "NotFound": {
+    "title": "Sorry, this page could not be found."
+  },
+  "PageLayout": {
+    "pageTitle": "next-intl"
+  },
+  "StrictTypes": {
+    "nested": {
+      "hello": "Hello",
+      "another": {
+        "level": "Level"
+      }
+    }
   }
 }

--- a/translations/codeExamples/next-intl/src/StrictTypesExample.tsx
+++ b/translations/codeExamples/next-intl/src/StrictTypesExample.tsx
@@ -1,0 +1,110 @@
+// https://github.com/amannn/next-intl/blob/main/examples/example-pages-router-advanced/src/pages/strict-types.tsx
+// @ts-nocheck
+import { NextIntlClientProvider, useTranslations } from "next-intl";
+
+function StrictTypesExample() {
+  useTranslations("StrictTypes")("nested.hello");
+  useTranslations("StrictTypes.nested")("another.level");
+  useTranslations("About")("title");
+  useTranslations("About")("lastUpdated");
+  useTranslations("Navigation")("about");
+  useTranslations()("About.title");
+  useTranslations()("Navigation.about");
+  useTranslations("NotFound")("title");
+  useTranslations("PageLayout")("pageTitle");
+
+  // @ts-expect-error Trying to access a child key without a namespace
+  useTranslations()("title");
+
+  // @ts-expect-error Only partial namespaces are allowed
+  useTranslations("About.title");
+
+  // @ts-expect-error Trying to access a key from another namespace
+  useTranslations("Test")("title");
+
+  // @ts-expect-error Invalid namespace
+  useTranslations("Unknown");
+
+  // @ts-expect-error Invalid key on global namespace
+  useTranslations()("unknown");
+
+  // @ts-expect-error Invalid key on valid namespace
+  useTranslations("About")("unknown");
+
+  // @ts-expect-error Invalid namespace and invalid key
+  useTranslations("unknown")("unknown");
+
+  /**
+   * `t.rich`
+   */
+
+  // Correct property access
+  useTranslations("StrictTypes").rich("nested.hello");
+  useTranslations("StrictTypes.nested").rich("another.level");
+  useTranslations("About").rich("title");
+  useTranslations("About").rich("lastUpdated");
+  useTranslations("Navigation").rich("about");
+  useTranslations().rich("About.title");
+  useTranslations().rich("Navigation.about");
+  useTranslations("NotFound").rich("title");
+  useTranslations("PageLayout").rich("pageTitle");
+
+  // @ts-expect-error Trying to access a child key without a namespace
+  useTranslations().rich("title");
+
+  // @ts-expect-error Only partial namespaces are allowed
+  useTranslations("About.title");
+
+  // @ts-expect-error Trying to access a key from another namespace
+  useTranslations("Test").rich("title");
+
+  // @ts-expect-error Invalid namespace
+  useTranslations("Unknown");
+
+  // @ts-expect-error Invalid key on global namespace
+  useTranslations().rich("unknown");
+
+  // @ts-expect-error Invalid key on valid namespace
+  useTranslations("About").rich("unknown");
+
+  // @ts-expect-error Invalid namespace and invalid key
+  useTranslations("unknown").rich("unknown");
+
+  /**
+   * `t.raw`
+   */
+
+  // Correct property access
+  useTranslations("StrictTypes").raw("nested.hello");
+  useTranslations("StrictTypes.nested").raw("another.level");
+  useTranslations("About").raw("title");
+  useTranslations("About").raw("lastUpdated");
+  useTranslations("Navigation").raw("about");
+  useTranslations().raw("About.title");
+  useTranslations().raw("Navigation.about");
+  useTranslations("NotFound").raw("title");
+  useTranslations("PageLayout").raw("pageTitle");
+
+  // @ts-expect-error Trying to access a child key without a namespace
+  useTranslations().raw("title");
+
+  // @ts-expect-error Only partial namespaces are allowed
+  useTranslations("About.title");
+
+  // @ts-expect-error Trying to access a key from another namespace
+  useTranslations("Test").raw("title");
+
+  // @ts-expect-error Invalid namespace
+  useTranslations("Unknown");
+
+  // @ts-expect-error Invalid key on global namespace
+  useTranslations().raw("unknown");
+
+  // @ts-expect-error Invalid key on valid namespace
+  useTranslations("About").raw("unknown");
+
+  // @ts-expect-error Invalid namespace and invalid key
+  useTranslations("unknown").raw("unknown");
+
+  return <div>Done</div>;
+}


### PR DESCRIPTION
Improve then `next-intl` key extraction to handle:

```ts
useTranslations("About")("title");
useTranslations("About").rich("title");
useTranslations().raw("Navigation.about");
```