### PR TITLE
Enable to define multiple unused source folders

### DIFF
--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -377,6 +377,41 @@ Found undefined keys!
       );
     });
 
+    it("should find unused and undefined keys for react-i18next applications with multiple source folders", (done) => {
+      exec(
+        "node dist/bin/index.js --source en --locales translations/codeExamples/reacti18next/locales -f i18next -u translations/codeExamples/reacti18next/src translations/codeExamples/reacti18next/secondSrcFolder --parser-component-functions WrappedTransComponent",
+        (_error, stdout, _stderr) => {
+          const result = stdout.split("Done")[0];
+          expect(result).toEqual(`i18n translations checker
+Source: en
+Selected format is: i18next
+
+No missing keys found!
+
+No invalid translations found!
+
+Found unused keys!
+┌──────────────────────────────────────────────────────────────────────┬──────────────────┐
+│ file                                                                 │ key              │
+├──────────────────────────────────────────────────────────────────────┼──────────────────┤
+│  translations/codeExamples/reacti18next/locales/en/translation.json  │  format.ebook    │
+│  translations/codeExamples/reacti18next/locales/en/translation.json  │  nonExistentKey  │
+└──────────────────────────────────────────────────────────────────────┴──────────────────┘
+
+Found undefined keys!
+┌───────────────────────────────────────────────────────────────────┬───────────────────────────────────┐
+│ file                                                              │ key                               │
+├───────────────────────────────────────────────────────────────────┼───────────────────────────────────┤
+│  translations/codeExamples/reacti18next/src/App.tsx               │  some.key.that.is.not.defined     │
+│  translations/codeExamples/reacti18next/secondSrcFolder/Main.tsx  │  another.key.that.is.not.defined  │
+└───────────────────────────────────────────────────────────────────┴───────────────────────────────────┘
+
+`);
+          done();
+        }
+      );
+    });
+
     it("should find unused and undefined keys for react-intl applications", (done) => {
       exec(
         "node dist/bin/index.js --source en-US --locales translations/codeExamples/react-intl/locales -f react-intl -u translations/codeExamples/react-intl/src",

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -47,8 +47,8 @@ program
     "define the file(s) and/or folders(s) that should be excluded from the check"
   )
   .option(
-    "-u, --unused <path>",
-    "define the source path to find all unused and undefined keys"
+    "-u, --unused <paths...>",
+    "define the source path(s) to find all unused and undefined keys"
   )
   .option(
     "--parser-component-functions <components...>",
@@ -248,7 +248,11 @@ const main = async () => {
     printTranslationResult(result);
 
     if (unusedSrcPath) {
-      const filesToParse = globSync(`${unusedSrcPath}/**/*.{ts,tsx}`, {
+      const isMultiUnusedFolders = unusedSrcPath.length > 1;
+      const pattern = isMultiUnusedFolders
+        ? `{${unusedSrcPath.join(",").trim()}}/**/*.{ts,tsx}`
+        : `${unusedSrcPath.join(",").trim()}/**/*.{ts,tsx}`;
+      const filesToParse = globSync(pattern, {
         ignore: ["node_modules/**"],
       });
 

--- a/translations/codeExamples/reacti18next/secondSrcFolder/Main.tsx
+++ b/translations/codeExamples/reacti18next/secondSrcFolder/Main.tsx
@@ -1,0 +1,73 @@
+// @ts-nocheck
+import React from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { Content } from "./Content";
+
+const WrappedTransComponent = (props) => {
+  return <Trans {...props} />;
+};
+
+export const I18NextExample = () => {
+  const { t } = useTranslation();
+
+  const userName = "User One";
+
+  const returnObjectLike = t("returnObjectLike", { returnObjects: true });
+
+  const resolution = returnObjectLike["one"];
+
+  // Define static keys for any dynamically defined keys for the parser to identify them
+  // https://github.com/i18next/i18next-parser?tab=readme-ov-file#caveats
+  // t('some.deep.nested.otherKey')
+  const option = "otherKey";
+
+  return (
+    <p className="example">
+      <p>
+        {t("some_placeholder", {
+          defaultValue: "A fallback {{ val }} - just in case",
+          val: "static value",
+        })}
+        {t("one", "Value one")}
+        {t("two", "Value two")}
+        {t("three", "Value three")}
+        {t("more", "More!")}
+        {t("another.key.that.is.not.defined", "Some key that is not defined!")}
+      </p>
+
+      <p>{t("testing.one", "Some default value")}</p>
+
+      <Trans i18nKey="moreInformationLink">
+        Welcome <b>{{ userName }}</b>, you can check for more information{" "}
+        <a href="some-link">here</a>!
+      </Trans>
+
+      <WrappedTransComponent i18nKey="test.one">
+        Welcome <b>{userName}</b>, you can check for more information{" "}
+        <a href="some-link">here</a>!
+      </WrappedTransComponent>
+
+      <WrappedTransComponent i18nKey="user.one" ns="one">
+        Welcome <b>{user}</b>!
+      </WrappedTransComponent>
+
+      <WrappedTransComponent
+        i18nKey="some.deep.nested.key"
+        ns="two"
+        components={[
+          <>
+            <div />
+          </>,
+        ]}
+      />
+
+      <div>{t(`some.deep.nested.${option}`)}</div>
+
+      <div>
+        <Trans i18nKey="content.intro" />
+        <Content />
+        <Trans i18nKey="content.outro" />
+      </div>
+    </p>
+  );
+};


### PR DESCRIPTION
Enables to define multiple `unused` paths:

```bash
--source en --locales translations/codeExamples/reacti18next/locales -f i18next -u translations/codeExamples/reacti18next/src translations/codeExamples/reacti18next/secondSrcFolder
```

resolves #56 