### PR TITLE
Fix cli tests on windows

### DIFF
--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -509,19 +509,19 @@ No missing keys found!
 No invalid translations found!
 
 Found unused keys!
-┌─────────────────────────────────────────────────────────────────┬─────────────────────────┐
-│ file                                                            │ key                     │
-├─────────────────────────────────────────────────────────────────┼─────────────────────────┤
-│  translations/codeExamples/react-intl/locales/en-US/one.json    │  message.number-format  │
-│  translations/codeExamples/react-intl/locales/en-US/three.json  │  multipleVariables      │
-└─────────────────────────────────────────────────────────────────┴─────────────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [codeEx("react-intl/locales/en-US/one.json"), "message.number-format"],
+    [codeEx("react-intl/locales/en-US/three.json"), "multipleVariables"],
+  ],
+])}
 
 Found undefined keys!
-┌────────────────────────────────────────────────────┬────────────────────────────────┐
-│ file                                               │ key                            │
-├────────────────────────────────────────────────────┼────────────────────────────────┤
-│  translations/codeExamples/react-intl/src/App.tsx  │  some.key.that.is.not.defined  │
-└────────────────────────────────────────────────────┴────────────────────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [[codeEx("react-intl/src/App.tsx"), "some.key.that.is.not.defined"]],
+])}
 
 `);
           done();
@@ -543,29 +543,31 @@ No missing keys found!
 No invalid translations found!
 
 Found unused keys!
-┌───────────────────────────────────────────────────────────────────┬──────────────────┐
-│ file                                                              │ key              │
-├───────────────────────────────────────────────────────────────────┼──────────────────┤
-│  translations/codeExamples/next-intl/locales/en/translation.json  │  message.plural  │
-│  translations/codeExamples/next-intl/locales/en/translation.json  │  notUsedKey      │
-└───────────────────────────────────────────────────────────────────┴──────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [codeEx("next-intl/locales/en/translation.json"), "message.plural"],
+    [codeEx("next-intl/locales/en/translation.json"), "notUsedKey"],
+  ],
+])}
 
 Found undefined keys!
-┌──────────────────────────────────────────────────────────────────┬───────────────────┐
-│ file                                                             │ key               │
-├──────────────────────────────────────────────────────────────────┼───────────────────┤
-│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  About.unknown    │
-│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  About.unknown    │
-│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  Test.title       │
-│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  Test.title       │
-│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  title            │
-│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  title            │
-│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  unknown          │
-│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  unknown          │
-│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  unknown.unknown  │
-│  translations/codeExamples/next-intl/src/StrictTypesExample.tsx  │  unknown.unknown  │
-│  translations/codeExamples/next-intl/src/Basic.tsx               │  message.select   │
-└──────────────────────────────────────────────────────────────────┴───────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [codeEx("next-intl/src/StrictTypesExample.tsx"), "About.unknown"],
+    [codeEx("next-intl/src/StrictTypesExample.tsx"), "About.unknown"],
+    [codeEx("next-intl/src/StrictTypesExample.tsx"), "Test.title"],
+    [codeEx("next-intl/src/StrictTypesExample.tsx"), "Test.title"],
+    [codeEx("next-intl/src/StrictTypesExample.tsx"), "title"],
+    [codeEx("next-intl/src/StrictTypesExample.tsx"), "title"],
+    [codeEx("next-intl/src/StrictTypesExample.tsx"), "unknown"],
+    [codeEx("next-intl/src/StrictTypesExample.tsx"), "unknown"],
+    [codeEx("next-intl/src/StrictTypesExample.tsx"), "unknown.unknown"],
+    [codeEx("next-intl/src/StrictTypesExample.tsx"), "unknown.unknown"],
+    [codeEx("next-intl/src/Basic.tsx"), "message.select"],
+  ],
+])}
 
 `);
           done();

--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -2,8 +2,20 @@ import { exec } from "child_process";
 import { formatTable } from "../errorReporters";
 import path from "path";
 
-function p(filePath: string) {
-  return path.join(filePath);
+function tr(file: string) {
+  return path.join("translations", file);
+}
+
+function multiFiles(file: string) {
+  return path.join("translations/multipleFilesFolderExample", file);
+}
+
+function multiFolders(file: string) {
+  return path.join("translations/multipleFoldersExample", file);
+}
+
+function codeEx(file: string) {
+  return path.join("translations/codeExamples", file);
 }
 
 describe("CLI", () => {
@@ -14,7 +26,7 @@ describe("CLI", () => {
         (_error, stdout, _stderr) => {
           const result = stdout.split("Done")[0];
 
-          const filePath = p("translations/flattenExamples/de-de.json");
+          const filePath = tr("flattenExamples/de-de.json");
           const table = formatTable([
             [["file", "key"]],
             [
@@ -45,18 +57,13 @@ No invalid translations found!
 
           const missingKeysTable = formatTable([
             [["file", "key"]],
-            [
-              [
-                p("translations/folderExample/de-DE/index.json"),
-                "message.text-format",
-              ],
-            ],
+            [[tr("folderExample/de-DE/index.json"), "message.text-format"]],
           ]);
 
           const invalidKeysTable = formatTable([
             [["info", "result"]],
             [
-              ["file", p("translations/folderExample/de-DE/index.json")],
+              ["file", tr("folderExample/de-DE/index.json")],
               ["key", "message.select"],
               [
                 "msg",
@@ -87,24 +94,15 @@ ${invalidKeysTable}
           const missingKeysTable = formatTable([
             [["file", "key"]],
             [
-              [
-                p("translations/multipleFilesFolderExample/de-DE/one.json"),
-                "message.text-format",
-              ],
-              [
-                p("translations/multipleFilesFolderExample/de-DE/two.json"),
-                "test.drive.four",
-              ],
+              [multiFiles("de-DE/one.json"), "message.text-format"],
+              [multiFiles("de-DE/two.json"), "test.drive.four"],
             ],
           ]);
 
           const invalidKeysTable = formatTable([
             [["info", "result"]],
             [
-              [
-                "file",
-                p("translations/multipleFilesFolderExample/de-DE/one.json"),
-              ],
+              ["file", multiFiles("de-DE/one.json")],
               ["key", "message.select"],
               [
                 "msg",
@@ -112,10 +110,7 @@ ${invalidKeysTable}
               ],
             ],
             [
-              [
-                "file",
-                p("translations/multipleFilesFolderExample/de-DE/three.json"),
-              ],
+              ["file", multiFiles("de-DE/three.json")],
               ["key", "multipleVariables"],
               [
                 "msg",
@@ -152,22 +147,10 @@ Found missing keys!
 ${formatTable([
   [["file", "key"]],
   [
-    [
-      p("translations/multipleFoldersExample/spaceOne/locales/de-DE/one.json"),
-      "message.text-format",
-    ],
-    [
-      p("translations/multipleFoldersExample/spaceOne/locales/de-DE/two.json"),
-      "test.drive.four",
-    ],
-    [
-      p("translations/multipleFoldersExample/spaceTwo/locales/de-DE/one.json"),
-      "message.plural",
-    ],
-    [
-      p("translations/multipleFoldersExample/spaceTwo/locales/de-DE/two.json"),
-      "test.drive.two",
-    ],
+    [multiFolders("spaceOne/locales/de-DE/one.json"), "message.text-format"],
+    [multiFolders("spaceOne/locales/de-DE/two.json"), "test.drive.four"],
+    [multiFolders("spaceTwo/locales/de-DE/one.json"), "message.plural"],
+    [multiFolders("spaceTwo/locales/de-DE/two.json"), "test.drive.two"],
   ],
 ])}
 
@@ -175,10 +158,7 @@ Found invalid keys!
 ${formatTable([
   [["info", "result"]],
   [
-    [
-      "file",
-      p("translations/multipleFoldersExample/spaceOne/locales/de-DE/one.json"),
-    ],
+    ["file", multiFolders("spaceOne/locales/de-DE/one.json")],
     ["key", "message.select"],
     [
       "msg",
@@ -186,20 +166,12 @@ ${formatTable([
     ],
   ],
   [
-    [
-      "file",
-      p(
-        "translations/multipleFoldersExample/spaceOne/locales/de-DE/three.json"
-      ),
-    ],
+    ["file", multiFolders("spaceOne/locales/de-DE/three.json")],
     ["key", "multipleVariables"],
     ["msg", 'Expected argument to contain "user" but received "name"'],
   ],
   [
-    [
-      "file",
-      p("translations/multipleFoldersExample/spaceTwo/locales/de-DE/one.json"),
-    ],
+    ["file", multiFolders("spaceTwo/locales/de-DE/one.json")],
     ["key", "message.text-format"],
     [
       "msg",
@@ -207,12 +179,7 @@ ${formatTable([
     ],
   ],
   [
-    [
-      "file",
-      p(
-        "translations/multipleFoldersExample/spaceTwo/locales/de-DE/three.json"
-      ),
-    ],
+    ["file", multiFolders("spaceTwo/locales/de-DE/three.json")],
     ["key", "numberFormat"],
     ["msg", "Missing element number"],
   ],
@@ -236,22 +203,10 @@ Found missing keys!
 ${formatTable([
   [["file", "key"]],
   [
-    [
-      p("translations/multipleFoldersExample/spaceOne/locales/de-DE/one.json"),
-      "message.text-format",
-    ],
-    [
-      p("translations/multipleFoldersExample/spaceOne/locales/de-DE/two.json"),
-      "test.drive.four",
-    ],
-    [
-      p("translations/multipleFoldersExample/spaceTwo/locales/de-DE/one.json"),
-      "message.plural",
-    ],
-    [
-      p("translations/multipleFoldersExample/spaceTwo/locales/de-DE/two.json"),
-      "test.drive.two",
-    ],
+    [multiFolders("spaceOne/locales/de-DE/one.json"), "message.text-format"],
+    [multiFolders("spaceOne/locales/de-DE/two.json"), "test.drive.four"],
+    [multiFolders("spaceTwo/locales/de-DE/one.json"), "message.plural"],
+    [multiFolders("spaceTwo/locales/de-DE/two.json"), "test.drive.two"],
   ],
 ])}
 
@@ -259,10 +214,7 @@ Found invalid keys!
 ${formatTable([
   [["info", "result"]],
   [
-    [
-      "file",
-      p("translations/multipleFoldersExample/spaceOne/locales/de-DE/one.json"),
-    ],
+    ["file", multiFolders("spaceOne/locales/de-DE/one.json")],
     ["key", "message.select"],
     [
       "msg",
@@ -270,20 +222,12 @@ ${formatTable([
     ],
   ],
   [
-    [
-      "file",
-      p(
-        "translations/multipleFoldersExample/spaceOne/locales/de-DE/three.json"
-      ),
-    ],
+    ["file", multiFolders("spaceOne/locales/de-DE/three.json")],
     ["key", "multipleVariables"],
     ["msg", 'Expected argument to contain "user" but received "name"'],
   ],
   [
-    [
-      "file",
-      p("translations/multipleFoldersExample/spaceTwo/locales/de-DE/one.json"),
-    ],
+    ["file", multiFolders("spaceTwo/locales/de-DE/one.json")],
     ["key", "message.text-format"],
     [
       "msg",
@@ -291,12 +235,7 @@ ${formatTable([
     ],
   ],
   [
-    [
-      "file",
-      p(
-        "translations/multipleFoldersExample/spaceTwo/locales/de-DE/three.json"
-      ),
-    ],
+    ["file", multiFolders("spaceTwo/locales/de-DE/three.json")],
     ["key", "numberFormat"],
     ["msg", "Missing element number"],
   ],
@@ -320,17 +259,14 @@ Found missing keys!
 ${formatTable([
   [["file", "key"]],
   [
-    [p("translations/flattenExamples/de-de.json"), "other.nested.three"],
-    [
-      p("translations/flattenExamples/de-de.json"),
-      "other.nested.deep.more.final",
-    ],
-    [p("translations/messageExamples/de-de.json"), "richText"],
-    [p("translations/messageExamples/de-de.json"), "yo"],
-    [p("translations/messageExamples/de-de.json"), "nesting1"],
-    [p("translations/messageExamples/de-de.json"), "nesting2"],
-    [p("translations/messageExamples/de-de.json"), "nesting3"],
-    [p("translations/messageExamples/de-de.json"), "key1"],
+    [tr("flattenExamples/de-de.json"), "other.nested.three"],
+    [tr("flattenExamples/de-de.json"), "other.nested.deep.more.final"],
+    [tr("messageExamples/de-de.json"), "richText"],
+    [tr("messageExamples/de-de.json"), "yo"],
+    [tr("messageExamples/de-de.json"), "nesting1"],
+    [tr("messageExamples/de-de.json"), "nesting2"],
+    [tr("messageExamples/de-de.json"), "nesting3"],
+    [tr("messageExamples/de-de.json"), "key1"],
   ],
 ])}
 
@@ -338,7 +274,7 @@ Found invalid keys!
 ${formatTable([
   [["info", "result"]],
   [
-    ["file", p("translations/messageExamples/de-de.json")],
+    ["file", tr("messageExamples/de-de.json")],
     ["key", "multipleVariables"],
     ["msg", "Unexpected date element"],
   ],
@@ -362,19 +298,10 @@ Found missing keys!
 ${formatTable([
   [["file", "key"]],
   [
-    [p("translations/flattenExamples/de-de.json"), "other.nested.three"],
-    [
-      p("translations/flattenExamples/de-de.json"),
-      "other.nested.deep.more.final",
-    ],
-    [
-      p("translations/multipleFilesFolderExample/de-DE/one.json"),
-      "message.text-format",
-    ],
-    [
-      p("translations/multipleFilesFolderExample/de-DE/two.json"),
-      "test.drive.four",
-    ],
+    [tr("flattenExamples/de-de.json"), "other.nested.three"],
+    [tr("flattenExamples/de-de.json"), "other.nested.deep.more.final"],
+    [multiFiles("de-DE/one.json"), "message.text-format"],
+    [multiFiles("de-DE/two.json"), "test.drive.four"],
   ],
 ])}
 
@@ -382,7 +309,7 @@ Found invalid keys!
 ${formatTable([
   [["info", "result"]],
   [
-    ["file", p("translations/multipleFilesFolderExample/de-DE/one.json")],
+    ["file", multiFiles("de-DE/one.json")],
     ["key", "message.select"],
     [
       "msg",
@@ -390,7 +317,7 @@ ${formatTable([
     ],
   ],
   [
-    ["file", p("translations/multipleFilesFolderExample/de-DE/three.json")],
+    ["file", multiFiles("de-DE/three.json")],
     ["key", "multipleVariables"],
     ["msg", 'Expected argument to contain "user" but received "name"'],
   ],
@@ -414,12 +341,12 @@ Found missing keys!
 ${formatTable([
   [["file", "key"]],
   [
-    [p("translations/messageExamples/de-de.json"), "richText"],
-    [p("translations/messageExamples/de-de.json"), "yo"],
-    [p("translations/messageExamples/de-de.json"), "nesting1"],
-    [p("translations/messageExamples/de-de.json"), "nesting2"],
-    [p("translations/messageExamples/de-de.json"), "nesting3"],
-    [p("translations/messageExamples/de-de.json"), "key1"],
+    [tr("messageExamples/de-de.json"), "richText"],
+    [tr("messageExamples/de-de.json"), "yo"],
+    [tr("messageExamples/de-de.json"), "nesting1"],
+    [tr("messageExamples/de-de.json"), "nesting2"],
+    [tr("messageExamples/de-de.json"), "nesting3"],
+    [tr("messageExamples/de-de.json"), "key1"],
   ],
 ])}
 
@@ -427,7 +354,7 @@ Found invalid keys!
 ${formatTable([
   [["info", "result"]],
   [
-    ["file", p("translations/messageExamples/de-de.json")],
+    ["file", tr("messageExamples/de-de.json")],
     ["key", "multipleVariables"],
     ["msg", "Unexpected date element"],
   ],
@@ -451,12 +378,12 @@ Found missing keys!
 ${formatTable([
   [["file", "key"]],
   [
-    [p("translations/messageExamples/de-de.json"), "richText"],
-    [p("translations/messageExamples/de-de.json"), "yo"],
-    [p("translations/messageExamples/de-de.json"), "nesting1"],
-    [p("translations/messageExamples/de-de.json"), "nesting2"],
-    [p("translations/messageExamples/de-de.json"), "nesting3"],
-    [p("translations/messageExamples/de-de.json"), "key1"],
+    [tr("messageExamples/de-de.json"), "richText"],
+    [tr("messageExamples/de-de.json"), "yo"],
+    [tr("messageExamples/de-de.json"), "nesting1"],
+    [tr("messageExamples/de-de.json"), "nesting2"],
+    [tr("messageExamples/de-de.json"), "nesting3"],
+    [tr("messageExamples/de-de.json"), "key1"],
   ],
 ])}
 
@@ -464,7 +391,7 @@ Found invalid keys!
 ${formatTable([
   [["info", "result"]],
   [
-    ["file", p("translations/messageExamples/de-de.json")],
+    ["file", tr("messageExamples/de-de.json")],
     ["key", "multipleVariables"],
     ["msg", "Unexpected date element"],
   ],
@@ -511,26 +438,15 @@ Found unused keys!
 ${formatTable([
   [["file", "key"]],
   [
-    [
-      p("translations/codeExamples/reacti18next/locales/en/translation.json"),
-      "format.ebook",
-    ],
-    [
-      p("translations/codeExamples/reacti18next/locales/en/translation.json"),
-      "nonExistentKey",
-    ],
+    [codeEx("reacti18next/locales/en/translation.json"), "format.ebook"],
+    [codeEx("reacti18next/locales/en/translation.json"), "nonExistentKey"],
   ],
 ])}
 
 Found undefined keys!
 ${formatTable([
   [["file", "key"]],
-  [
-    [
-      p("translations/codeExamples/reacti18next/src/App.tsx"),
-      "some.key.that.is.not.defined",
-    ],
-  ],
+  [[codeEx("reacti18next/src/App.tsx"), "some.key.that.is.not.defined"]],
 ])}
 
 `);
@@ -556,14 +472,8 @@ Found unused keys!
 ${formatTable([
   [["file", "key"]],
   [
-    [
-      p("translations/codeExamples/reacti18next/locales/en/translation.json"),
-      "format.ebook",
-    ],
-    [
-      p("translations/codeExamples/reacti18next/locales/en/translation.json"),
-      "nonExistentKey",
-    ],
+    [codeEx("reacti18next/locales/en/translation.json"), "format.ebook"],
+    [codeEx("reacti18next/locales/en/translation.json"), "nonExistentKey"],
   ],
 ])}
 
@@ -571,12 +481,9 @@ Found undefined keys!
 ${formatTable([
   [["file", "key"]],
   [
+    [codeEx("reacti18next/src/App.tsx"), "some.key.that.is.not.defined"],
     [
-      p("translations/codeExamples/reacti18next/src/App.tsx"),
-      "some.key.that.is.not.defined",
-    ],
-    [
-      p("translations/codeExamples/reacti18next/secondSrcFolder/Main.tsx"),
+      codeEx("reacti18next/secondSrcFolder/Main.tsx"),
       "another.key.that.is.not.defined",
     ],
   ],

--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -2,19 +2,19 @@ import { exec } from "child_process";
 import { formatTable } from "../errorReporters";
 import path from "path";
 
+function p(filePath: string) {
+  return path.join(filePath);
+}
+
 describe("CLI", () => {
   describe("JSON", () => {
-    it.only("should return the missing keys for single folder translations", (done) => {
+    it("should return the missing keys for single folder translations", (done) => {
       exec(
         "node dist/bin/index.js -s en-US -l translations/flattenExamples",
         (_error, stdout, _stderr) => {
           const result = stdout.split("Done")[0];
 
-          const filePath = path.join(
-            "translations",
-            "flattenExamples",
-            "de-de.json"
-          );
+          const filePath = p("translations/flattenExamples/de-de.json");
           const table = formatTable([
             [["file", "key"]],
             [
@@ -37,7 +37,7 @@ No invalid translations found!
       );
     });
 
-    it.only("should return the missing/invalid keys for folder per locale with single file", (done) => {
+    it("should return the missing/invalid keys for folder per locale with single file", (done) => {
       exec(
         "node dist/bin/index.js -l translations/folderExample/ -s en-US",
         (_error, stdout, _stderr) => {
@@ -47,7 +47,7 @@ No invalid translations found!
             [["file", "key"]],
             [
               [
-                path.join("translations/folderExample/de-DE", "index.json"),
+                p("translations/folderExample/de-DE/index.json"),
                 "message.text-format",
               ],
             ],
@@ -56,10 +56,7 @@ No invalid translations found!
           const invalidKeysTable = formatTable([
             [["info", "result"]],
             [
-              [
-                "file",
-                path.join("translations/folderExample/de-DE", "index.json"),
-              ],
+              ["file", p("translations/folderExample/de-DE/index.json")],
               ["key", "message.select"],
               [
                 "msg",
@@ -83,7 +80,7 @@ ${invalidKeysTable}
       );
     });
 
-    it.only("should return the missing/invalid keys for folder per locale with multiple files", (done) => {
+    it("should return the missing/invalid keys for folder per locale with multiple files", (done) => {
       exec(
         "node dist/bin/index.js -l translations/multipleFilesFolderExample/ -s en-US",
         (_error, stdout, _stderr) => {
@@ -91,17 +88,11 @@ ${invalidKeysTable}
             [["file", "key"]],
             [
               [
-                path.join(
-                  "translations/multipleFilesFolderExample/de-DE",
-                  "one.json"
-                ),
+                p("translations/multipleFilesFolderExample/de-DE/one.json"),
                 "message.text-format",
               ],
               [
-                path.join(
-                  "translations/multipleFilesFolderExample/de-DE",
-                  "two.json"
-                ),
+                p("translations/multipleFilesFolderExample/de-DE/two.json"),
                 "test.drive.four",
               ],
             ],
@@ -112,10 +103,7 @@ ${invalidKeysTable}
             [
               [
                 "file",
-                path.join(
-                  "translations/multipleFilesFolderExample/de-DE",
-                  "one.json"
-                ),
+                p("translations/multipleFilesFolderExample/de-DE/one.json"),
               ],
               ["key", "message.select"],
               [
@@ -126,10 +114,7 @@ ${invalidKeysTable}
             [
               [
                 "file",
-                path.join(
-                  "translations/multipleFilesFolderExample/de-DE",
-                  "three.json"
-                ),
+                p("translations/multipleFilesFolderExample/de-DE/three.json"),
               ],
               ["key", "multipleVariables"],
               [
@@ -164,35 +149,74 @@ ${invalidKeysTable}
 Source: en-US
 
 Found missing keys!
-┌───────────────────────────────────────────────────────────────────────┬───────────────────────┐
-│ file                                                                  │ key                   │
-├───────────────────────────────────────────────────────────────────────┼───────────────────────┤
-│  translations/multipleFoldersExample/spaceOne/locales/de-DE/one.json  │  message.text-format  │
-│  translations/multipleFoldersExample/spaceOne/locales/de-DE/two.json  │  test.drive.four      │
-│  translations/multipleFoldersExample/spaceTwo/locales/de-DE/one.json  │  message.plural       │
-│  translations/multipleFoldersExample/spaceTwo/locales/de-DE/two.json  │  test.drive.two       │
-└───────────────────────────────────────────────────────────────────────┴───────────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [
+      p("translations/multipleFoldersExample/spaceOne/locales/de-DE/one.json"),
+      "message.text-format",
+    ],
+    [
+      p("translations/multipleFoldersExample/spaceOne/locales/de-DE/two.json"),
+      "test.drive.four",
+    ],
+    [
+      p("translations/multipleFoldersExample/spaceTwo/locales/de-DE/one.json"),
+      "message.plural",
+    ],
+    [
+      p("translations/multipleFoldersExample/spaceTwo/locales/de-DE/two.json"),
+      "test.drive.two",
+    ],
+  ],
+])}
 
 Found invalid keys!
-┌────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ info   │ result                                                                                                           │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/multipleFoldersExample/spaceOne/locales/de-DE/one.json                                             │
-│  key   │  message.select                                                                                                  │
-│  msg   │  Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...  │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/multipleFoldersExample/spaceOne/locales/de-DE/three.json                                           │
-│  key   │  multipleVariables                                                                                               │
-│  msg   │  Expected argument to contain "user" but received "name"                                                         │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/multipleFoldersExample/spaceTwo/locales/de-DE/one.json                                             │
-│  key   │  message.text-format                                                                                             │
-│  msg   │  Expected element of type "tag" but received "number", Unexpected tag element                                    │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/multipleFoldersExample/spaceTwo/locales/de-DE/three.json                                           │
-│  key   │  numberFormat                                                                                                    │
-│  msg   │  Missing element number                                                                                          │
-└────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+${formatTable([
+  [["info", "result"]],
+  [
+    [
+      "file",
+      p("translations/multipleFoldersExample/spaceOne/locales/de-DE/one.json"),
+    ],
+    ["key", "message.select"],
+    [
+      "msg",
+      'Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...',
+    ],
+  ],
+  [
+    [
+      "file",
+      p(
+        "translations/multipleFoldersExample/spaceOne/locales/de-DE/three.json"
+      ),
+    ],
+    ["key", "multipleVariables"],
+    ["msg", 'Expected argument to contain "user" but received "name"'],
+  ],
+  [
+    [
+      "file",
+      p("translations/multipleFoldersExample/spaceTwo/locales/de-DE/one.json"),
+    ],
+    ["key", "message.text-format"],
+    [
+      "msg",
+      'Expected element of type "tag" but received "number", Unexpected tag element',
+    ],
+  ],
+  [
+    [
+      "file",
+      p(
+        "translations/multipleFoldersExample/spaceTwo/locales/de-DE/three.json"
+      ),
+    ],
+    ["key", "numberFormat"],
+    ["msg", "Missing element number"],
+  ],
+])}
 
 `);
           done();
@@ -209,35 +233,74 @@ Found invalid keys!
 Source: en-US
 
 Found missing keys!
-┌───────────────────────────────────────────────────────────────────────┬───────────────────────┐
-│ file                                                                  │ key                   │
-├───────────────────────────────────────────────────────────────────────┼───────────────────────┤
-│  translations/multipleFoldersExample/spaceOne/locales/de-DE/one.json  │  message.text-format  │
-│  translations/multipleFoldersExample/spaceOne/locales/de-DE/two.json  │  test.drive.four      │
-│  translations/multipleFoldersExample/spaceTwo/locales/de-DE/one.json  │  message.plural       │
-│  translations/multipleFoldersExample/spaceTwo/locales/de-DE/two.json  │  test.drive.two       │
-└───────────────────────────────────────────────────────────────────────┴───────────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [
+      p("translations/multipleFoldersExample/spaceOne/locales/de-DE/one.json"),
+      "message.text-format",
+    ],
+    [
+      p("translations/multipleFoldersExample/spaceOne/locales/de-DE/two.json"),
+      "test.drive.four",
+    ],
+    [
+      p("translations/multipleFoldersExample/spaceTwo/locales/de-DE/one.json"),
+      "message.plural",
+    ],
+    [
+      p("translations/multipleFoldersExample/spaceTwo/locales/de-DE/two.json"),
+      "test.drive.two",
+    ],
+  ],
+])}
 
 Found invalid keys!
-┌────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ info   │ result                                                                                                           │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/multipleFoldersExample/spaceOne/locales/de-DE/one.json                                             │
-│  key   │  message.select                                                                                                  │
-│  msg   │  Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...  │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/multipleFoldersExample/spaceOne/locales/de-DE/three.json                                           │
-│  key   │  multipleVariables                                                                                               │
-│  msg   │  Expected argument to contain "user" but received "name"                                                         │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/multipleFoldersExample/spaceTwo/locales/de-DE/one.json                                             │
-│  key   │  message.text-format                                                                                             │
-│  msg   │  Expected element of type "tag" but received "number", Unexpected tag element                                    │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/multipleFoldersExample/spaceTwo/locales/de-DE/three.json                                           │
-│  key   │  numberFormat                                                                                                    │
-│  msg   │  Missing element number                                                                                          │
-└────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+${formatTable([
+  [["info", "result"]],
+  [
+    [
+      "file",
+      p("translations/multipleFoldersExample/spaceOne/locales/de-DE/one.json"),
+    ],
+    ["key", "message.select"],
+    [
+      "msg",
+      'Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...',
+    ],
+  ],
+  [
+    [
+      "file",
+      p(
+        "translations/multipleFoldersExample/spaceOne/locales/de-DE/three.json"
+      ),
+    ],
+    ["key", "multipleVariables"],
+    ["msg", 'Expected argument to contain "user" but received "name"'],
+  ],
+  [
+    [
+      "file",
+      p("translations/multipleFoldersExample/spaceTwo/locales/de-DE/one.json"),
+    ],
+    ["key", "message.text-format"],
+    [
+      "msg",
+      'Expected element of type "tag" but received "number", Unexpected tag element',
+    ],
+  ],
+  [
+    [
+      "file",
+      p(
+        "translations/multipleFoldersExample/spaceTwo/locales/de-DE/three.json"
+      ),
+    ],
+    ["key", "numberFormat"],
+    ["msg", "Missing element number"],
+  ],
+])}
 
 `);
           done();
@@ -254,27 +317,32 @@ Found invalid keys!
 Source: en-US
 
 Found missing keys!
-┌───────────────────────────────────────────┬────────────────────────────────┐
-│ file                                      │ key                            │
-├───────────────────────────────────────────┼────────────────────────────────┤
-│  translations/flattenExamples/de-de.json  │  other.nested.three            │
-│  translations/flattenExamples/de-de.json  │  other.nested.deep.more.final  │
-│  translations/messageExamples/de-de.json  │  richText                      │
-│  translations/messageExamples/de-de.json  │  yo                            │
-│  translations/messageExamples/de-de.json  │  nesting1                      │
-│  translations/messageExamples/de-de.json  │  nesting2                      │
-│  translations/messageExamples/de-de.json  │  nesting3                      │
-│  translations/messageExamples/de-de.json  │  key1                          │
-└───────────────────────────────────────────┴────────────────────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [p("translations/flattenExamples/de-de.json"), "other.nested.three"],
+    [
+      p("translations/flattenExamples/de-de.json"),
+      "other.nested.deep.more.final",
+    ],
+    [p("translations/messageExamples/de-de.json"), "richText"],
+    [p("translations/messageExamples/de-de.json"), "yo"],
+    [p("translations/messageExamples/de-de.json"), "nesting1"],
+    [p("translations/messageExamples/de-de.json"), "nesting2"],
+    [p("translations/messageExamples/de-de.json"), "nesting3"],
+    [p("translations/messageExamples/de-de.json"), "key1"],
+  ],
+])}
 
 Found invalid keys!
-┌────────┬───────────────────────────────────────────┐
-│ info   │ result                                    │
-├────────┼───────────────────────────────────────────┤
-│  file  │  translations/messageExamples/de-de.json  │
-│  key   │  multipleVariables                        │
-│  msg   │  Unexpected date element                  │
-└────────┴───────────────────────────────────────────┘
+${formatTable([
+  [["info", "result"]],
+  [
+    ["file", p("translations/messageExamples/de-de.json")],
+    ["key", "multipleVariables"],
+    ["msg", "Unexpected date element"],
+  ],
+])}
 
 `);
           done();

--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -1,22 +1,33 @@
 import { exec } from "child_process";
+import { formatTable } from "../errorReporters";
+import path from "path";
 
 describe("CLI", () => {
   describe("JSON", () => {
-    it("should return the missing keys for single folder translations", (done) => {
+    it.only("should return the missing keys for single folder translations", (done) => {
       exec(
         "node dist/bin/index.js -s en-US -l translations/flattenExamples",
         (_error, stdout, _stderr) => {
           const result = stdout.split("Done")[0];
+
+          const filePath = path.join(
+            "translations",
+            "flattenExamples",
+            "de-de.json"
+          );
+          const table = formatTable([
+            [["file", "key"]],
+            [
+              [filePath, "other.nested.three"],
+              [filePath, "other.nested.deep.more.final"],
+            ],
+          ]);
+
           expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
-┌───────────────────────────────────────────┬────────────────────────────────┐
-│ file                                      │ key                            │
-├───────────────────────────────────────────┼────────────────────────────────┤
-│  translations/flattenExamples/de-de.json  │  other.nested.three            │
-│  translations/flattenExamples/de-de.json  │  other.nested.deep.more.final  │
-└───────────────────────────────────────────┴────────────────────────────────┘
+${table}
 
 No invalid translations found!
 
@@ -26,29 +37,45 @@ No invalid translations found!
       );
     });
 
-    it("should return the missing/invalid keys for folder per locale with single file", (done) => {
+    it.only("should return the missing/invalid keys for folder per locale with single file", (done) => {
       exec(
         "node dist/bin/index.js -l translations/folderExample/ -s en-US",
         (_error, stdout, _stderr) => {
           const result = stdout.split("Done")[0];
+
+          const missingKeysTable = formatTable([
+            [["file", "key"]],
+            [
+              [
+                path.join("translations/folderExample/de-DE", "index.json"),
+                "message.text-format",
+              ],
+            ],
+          ]);
+
+          const invalidKeysTable = formatTable([
+            [["info", "result"]],
+            [
+              [
+                "file",
+                path.join("translations/folderExample/de-DE", "index.json"),
+              ],
+              ["key", "message.select"],
+              [
+                "msg",
+                'Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...',
+              ],
+            ],
+          ]);
+
           expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
-┌───────────────────────────────────────────────┬───────────────────────┐
-│ file                                          │ key                   │
-├───────────────────────────────────────────────┼───────────────────────┤
-│  translations/folderExample/de-DE/index.json  │  message.text-format  │
-└───────────────────────────────────────────────┴───────────────────────┘
+${missingKeysTable}
 
 Found invalid keys!
-┌────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ info   │ result                                                                                                           │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/folderExample/de-DE/index.json                                                                     │
-│  key   │  message.select                                                                                                  │
-│  msg   │  Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...  │
-└────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+${invalidKeysTable}
 
 `);
           done();
@@ -56,34 +83,71 @@ Found invalid keys!
       );
     });
 
-    it("should return the missing/invalid keys for folder per locale with multiple files", (done) => {
+    it.only("should return the missing/invalid keys for folder per locale with multiple files", (done) => {
       exec(
         "node dist/bin/index.js -l translations/multipleFilesFolderExample/ -s en-US",
         (_error, stdout, _stderr) => {
+          const missingKeysTable = formatTable([
+            [["file", "key"]],
+            [
+              [
+                path.join(
+                  "translations/multipleFilesFolderExample/de-DE",
+                  "one.json"
+                ),
+                "message.text-format",
+              ],
+              [
+                path.join(
+                  "translations/multipleFilesFolderExample/de-DE",
+                  "two.json"
+                ),
+                "test.drive.four",
+              ],
+            ],
+          ]);
+
+          const invalidKeysTable = formatTable([
+            [["info", "result"]],
+            [
+              [
+                "file",
+                path.join(
+                  "translations/multipleFilesFolderExample/de-DE",
+                  "one.json"
+                ),
+              ],
+              ["key", "message.select"],
+              [
+                "msg",
+                'Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...',
+              ],
+            ],
+            [
+              [
+                "file",
+                path.join(
+                  "translations/multipleFilesFolderExample/de-DE",
+                  "three.json"
+                ),
+              ],
+              ["key", "multipleVariables"],
+              [
+                "msg",
+                'Expected argument to contain "user" but received "name"  ',
+              ],
+            ],
+          ]);
+
           const result = stdout.split("Done")[0];
           expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
-┌──────────────────────────────────────────────────────────┬───────────────────────┐
-│ file                                                     │ key                   │
-├──────────────────────────────────────────────────────────┼───────────────────────┤
-│  translations/multipleFilesFolderExample/de-DE/one.json  │  message.text-format  │
-│  translations/multipleFilesFolderExample/de-DE/two.json  │  test.drive.four      │
-└──────────────────────────────────────────────────────────┴───────────────────────┘
+${missingKeysTable}
 
 Found invalid keys!
-┌────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ info   │ result                                                                                                           │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/multipleFilesFolderExample/de-DE/one.json                                                          │
-│  key   │  message.select                                                                                                  │
-│  msg   │  Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...  │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/multipleFilesFolderExample/de-DE/three.json                                                        │
-│  key   │  multipleVariables                                                                                               │
-│  msg   │  Expected argument to contain "user" but received "name"                                                         │
-└────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+${invalidKeysTable}
 
 `);
           done();

--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -18,6 +18,10 @@ function codeEx(file: string) {
   return path.join("translations/codeExamples", file);
 }
 
+function ymlMultiFolders(file: string) {
+  return path.join("translations/yaml/multipleFoldersExample", file);
+}
+
 describe("CLI", () => {
   describe("JSON", () => {
     it("should return the missing keys for single folder translations", (done) => {
@@ -586,12 +590,13 @@ ${formatTable([
 Source: en-US
 
 Found missing keys!
-┌────────────────────────────────────────────────┬────────────────────────────────┐
-│ file                                           │ key                            │
-├────────────────────────────────────────────────┼────────────────────────────────┤
-│  translations/yaml/flattenExamples/de-de.yaml  │  other.nested.three            │
-│  translations/yaml/flattenExamples/de-de.yaml  │  other.nested.deep.more.final  │
-└────────────────────────────────────────────────┴────────────────────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [tr("yaml/flattenExamples/de-de.yaml"), "other.nested.three"],
+    [tr("yaml/flattenExamples/de-de.yaml"), "other.nested.deep.more.final"],
+  ],
+])}
 
 No invalid translations found!
 
@@ -610,20 +615,23 @@ No invalid translations found!
 Source: en-US
 
 Found missing keys!
-┌────────────────────────────────────────────────────┬───────────────────────┐
-│ file                                               │ key                   │
-├────────────────────────────────────────────────────┼───────────────────────┤
-│  translations/yaml/folderExample/de-DE/index.yaml  │  message.text-format  │
-└────────────────────────────────────────────────────┴───────────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [[tr("yaml/folderExample/de-DE/index.yaml"), "message.text-format"]],
+])}
 
 Found invalid keys!
-┌────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ info   │ result                                                                                                           │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/yaml/folderExample/de-DE/index.yaml                                                                │
-│  key   │  message.select                                                                                                  │
-│  msg   │  Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...  │
-└────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+${formatTable([
+  [["info", "result"]],
+  [
+    ["file", tr("yaml/folderExample/de-DE/index.yaml")],
+    ["key", "message.select"],
+    [
+      "msg",
+      'Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...',
+    ],
+  ],
+])}
 
 `);
           done();
@@ -640,25 +648,34 @@ Found invalid keys!
 Source: en-US
 
 Found missing keys!
-┌───────────────────────────────────────────────────────────────┬───────────────────────┐
-│ file                                                          │ key                   │
-├───────────────────────────────────────────────────────────────┼───────────────────────┤
-│  translations/yaml/multipleFilesFolderExample/de-DE/one.yaml  │  message.text-format  │
-│  translations/yaml/multipleFilesFolderExample/de-DE/two.yaml  │  test.drive.four      │
-└───────────────────────────────────────────────────────────────┴───────────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [
+      tr("yaml/multipleFilesFolderExample/de-DE/one.yaml"),
+      "message.text-format",
+    ],
+    [tr("yaml/multipleFilesFolderExample/de-DE/two.yaml"), "test.drive.four"],
+  ],
+])}
 
 Found invalid keys!
-┌────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ info   │ result                                                                                                           │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/yaml/multipleFilesFolderExample/de-DE/one.yaml                                                     │
-│  key   │  message.select                                                                                                  │
-│  msg   │  Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...  │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/yaml/multipleFilesFolderExample/de-DE/three.yaml                                                   │
-│  key   │  multipleVariables                                                                                               │
-│  msg   │  Expected argument to contain "user" but received "name"                                                         │
-└────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+${formatTable([
+  [["info", "result"]],
+  [
+    ["file", tr("yaml/multipleFilesFolderExample/de-DE/one.yaml")],
+    ["key", "message.select"],
+    [
+      "msg",
+      'Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...',
+    ],
+  ],
+  [
+    ["file", tr("yaml/multipleFilesFolderExample/de-DE/three.yaml")],
+    ["key", "multipleVariables"],
+    ["msg", 'Expected argument to contain "user" but received "name"'],
+  ],
+])}
 
 `);
           done();
@@ -675,35 +692,46 @@ Found invalid keys!
 Source: en-US
 
 Found missing keys!
-┌────────────────────────────────────────────────────────────────────────────┬───────────────────────┐
-│ file                                                                       │ key                   │
-├────────────────────────────────────────────────────────────────────────────┼───────────────────────┤
-│  translations/yaml/multipleFoldersExample/spaceOne/locales/de-DE/one.yaml  │  message.text-format  │
-│  translations/yaml/multipleFoldersExample/spaceOne/locales/de-DE/two.yaml  │  test.drive.four      │
-│  translations/yaml/multipleFoldersExample/spaceTwo/locales/de-DE/one.yaml  │  message.plural       │
-│  translations/yaml/multipleFoldersExample/spaceTwo/locales/de-DE/two.yaml  │  test.drive.two       │
-└────────────────────────────────────────────────────────────────────────────┴───────────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [ymlMultiFolders("spaceOne/locales/de-DE/one.yaml"), "message.text-format"],
+    [ymlMultiFolders("spaceOne/locales/de-DE/two.yaml"), "test.drive.four"],
+    [ymlMultiFolders("spaceTwo/locales/de-DE/one.yaml"), "message.plural"],
+    [ymlMultiFolders("spaceTwo/locales/de-DE/two.yaml"), "test.drive.two"],
+  ],
+])}
 
 Found invalid keys!
-┌────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ info   │ result                                                                                                           │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/yaml/multipleFoldersExample/spaceOne/locales/de-DE/one.yaml                                        │
-│  key   │  message.select                                                                                                  │
-│  msg   │  Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...  │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/yaml/multipleFoldersExample/spaceOne/locales/de-DE/three.yaml                                      │
-│  key   │  multipleVariables                                                                                               │
-│  msg   │  Expected argument to contain "user" but received "name"                                                         │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/yaml/multipleFoldersExample/spaceTwo/locales/de-DE/one.yaml                                        │
-│  key   │  message.text-format                                                                                             │
-│  msg   │  Expected element of type "tag" but received "number", Unexpected tag element                                    │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/yaml/multipleFoldersExample/spaceTwo/locales/de-DE/three.yaml                                      │
-│  key   │  numberFormat                                                                                                    │
-│  msg   │  Missing element number                                                                                          │
-└────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+${formatTable([
+  [["info", "result"]],
+  [
+    ["file", ymlMultiFolders("spaceOne/locales/de-DE/one.yaml")],
+    ["key", "message.select"],
+    [
+      "msg",
+      'Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...',
+    ],
+  ],
+  [
+    ["file", ymlMultiFolders("spaceOne/locales/de-DE/three.yaml")],
+    ["key", "multipleVariables"],
+    ["msg", 'Expected argument to contain "user" but received "name"'],
+  ],
+  [
+    ["file", ymlMultiFolders("spaceTwo/locales/de-DE/one.yaml")],
+    ["key", "message.text-format"],
+    [
+      "msg",
+      'Expected element of type "tag" but received "number", Unexpected tag element',
+    ],
+  ],
+  [
+    ["file", ymlMultiFolders("spaceTwo/locales/de-DE/three.yaml")],
+    ["key", "numberFormat"],
+    ["msg", "Missing element number"],
+  ],
+])}
 
 `);
           done();
@@ -720,35 +748,46 @@ Found invalid keys!
 Source: en-US
 
 Found missing keys!
-┌────────────────────────────────────────────────────────────────────────────┬───────────────────────┐
-│ file                                                                       │ key                   │
-├────────────────────────────────────────────────────────────────────────────┼───────────────────────┤
-│  translations/yaml/multipleFoldersExample/spaceOne/locales/de-DE/one.yaml  │  message.text-format  │
-│  translations/yaml/multipleFoldersExample/spaceOne/locales/de-DE/two.yaml  │  test.drive.four      │
-│  translations/yaml/multipleFoldersExample/spaceTwo/locales/de-DE/one.yaml  │  message.plural       │
-│  translations/yaml/multipleFoldersExample/spaceTwo/locales/de-DE/two.yaml  │  test.drive.two       │
-└────────────────────────────────────────────────────────────────────────────┴───────────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [ymlMultiFolders("spaceOne/locales/de-DE/one.yaml"), "message.text-format"],
+    [ymlMultiFolders("spaceOne/locales/de-DE/two.yaml"), "test.drive.four"],
+    [ymlMultiFolders("spaceTwo/locales/de-DE/one.yaml"), "message.plural"],
+    [ymlMultiFolders("spaceTwo/locales/de-DE/two.yaml"), "test.drive.two"],
+  ],
+])}
 
 Found invalid keys!
-┌────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ info   │ result                                                                                                           │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/yaml/multipleFoldersExample/spaceOne/locales/de-DE/one.yaml                                        │
-│  key   │  message.select                                                                                                  │
-│  msg   │  Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...  │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/yaml/multipleFoldersExample/spaceOne/locales/de-DE/three.yaml                                      │
-│  key   │  multipleVariables                                                                                               │
-│  msg   │  Expected argument to contain "user" but received "name"                                                         │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/yaml/multipleFoldersExample/spaceTwo/locales/de-DE/one.yaml                                        │
-│  key   │  message.text-format                                                                                             │
-│  msg   │  Expected element of type "tag" but received "number", Unexpected tag element                                    │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/yaml/multipleFoldersExample/spaceTwo/locales/de-DE/three.yaml                                      │
-│  key   │  numberFormat                                                                                                    │
-│  msg   │  Missing element number                                                                                          │
-└────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+${formatTable([
+  [["info", "result"]],
+  [
+    ["file", ymlMultiFolders("spaceOne/locales/de-DE/one.yaml")],
+    ["key", "message.select"],
+    [
+      "msg",
+      'Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...',
+    ],
+  ],
+  [
+    ["file", ymlMultiFolders("spaceOne/locales/de-DE/three.yaml")],
+    ["key", "multipleVariables"],
+    ["msg", 'Expected argument to contain "user" but received "name"'],
+  ],
+  [
+    ["file", ymlMultiFolders("spaceTwo/locales/de-DE/one.yaml")],
+    ["key", "message.text-format"],
+    [
+      "msg",
+      'Expected element of type "tag" but received "number", Unexpected tag element',
+    ],
+  ],
+  [
+    ["file", ymlMultiFolders("spaceTwo/locales/de-DE/three.yaml")],
+    ["key", "numberFormat"],
+    ["msg", "Missing element number"],
+  ],
+])}
 
 `);
           done();
@@ -765,27 +804,29 @@ Found invalid keys!
 Source: en-US
 
 Found missing keys!
-┌────────────────────────────────────────────────┬────────────────────────────────┐
-│ file                                           │ key                            │
-├────────────────────────────────────────────────┼────────────────────────────────┤
-│  translations/yaml/flattenExamples/de-de.yaml  │  other.nested.three            │
-│  translations/yaml/flattenExamples/de-de.yaml  │  other.nested.deep.more.final  │
-│  translations/yaml/messageExamples/de-de.yaml  │  richText                      │
-│  translations/yaml/messageExamples/de-de.yaml  │  yo                            │
-│  translations/yaml/messageExamples/de-de.yaml  │  nesting1                      │
-│  translations/yaml/messageExamples/de-de.yaml  │  nesting2                      │
-│  translations/yaml/messageExamples/de-de.yaml  │  nesting3                      │
-│  translations/yaml/messageExamples/de-de.yaml  │  key1                          │
-└────────────────────────────────────────────────┴────────────────────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [tr("yaml/flattenExamples/de-de.yaml"), "other.nested.three"],
+    [tr("yaml/flattenExamples/de-de.yaml"), "other.nested.deep.more.final"],
+    [tr("yaml/messageExamples/de-de.yaml"), "richText"],
+    [tr("yaml/messageExamples/de-de.yaml"), "yo"],
+    [tr("yaml/messageExamples/de-de.yaml"), "nesting1"],
+    [tr("yaml/messageExamples/de-de.yaml"), "nesting2"],
+    [tr("yaml/messageExamples/de-de.yaml"), "nesting3"],
+    [tr("yaml/messageExamples/de-de.yaml"), "key1"],
+  ],
+])}
 
 Found invalid keys!
-┌────────┬────────────────────────────────────────────────┐
-│ info   │ result                                         │
-├────────┼────────────────────────────────────────────────┤
-│  file  │  translations/yaml/messageExamples/de-de.yaml  │
-│  key   │  multipleVariables                             │
-│  msg   │  Unexpected date element                       │
-└────────┴────────────────────────────────────────────────┘
+${formatTable([
+  [["info", "result"]],
+  [
+    ["file", tr("yaml/messageExamples/de-de.yaml")],
+    ["key", "multipleVariables"],
+    ["msg", "Unexpected date element"],
+  ],
+])}
 
 `);
           done();
@@ -802,27 +843,36 @@ Found invalid keys!
 Source: en-US
 
 Found missing keys!
-┌───────────────────────────────────────────────────────────────┬────────────────────────────────┐
-│ file                                                          │ key                            │
-├───────────────────────────────────────────────────────────────┼────────────────────────────────┤
-│  translations/yaml/flattenExamples/de-de.yaml                 │  other.nested.three            │
-│  translations/yaml/flattenExamples/de-de.yaml                 │  other.nested.deep.more.final  │
-│  translations/yaml/multipleFilesFolderExample/de-DE/one.yaml  │  message.text-format           │
-│  translations/yaml/multipleFilesFolderExample/de-DE/two.yaml  │  test.drive.four               │
-└───────────────────────────────────────────────────────────────┴────────────────────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [tr("yaml/flattenExamples/de-de.yaml"), "other.nested.three"],
+    [tr("yaml/flattenExamples/de-de.yaml"), "other.nested.deep.more.final"],
+    [
+      tr("yaml/multipleFilesFolderExample/de-DE/one.yaml"),
+      "message.text-format",
+    ],
+    [tr("yaml/multipleFilesFolderExample/de-DE/two.yaml"), "test.drive.four"],
+  ],
+])}
 
 Found invalid keys!
-┌────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ info   │ result                                                                                                           │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/yaml/multipleFilesFolderExample/de-DE/one.yaml                                                     │
-│  key   │  message.select                                                                                                  │
-│  msg   │  Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...  │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/yaml/multipleFilesFolderExample/de-DE/three.yaml                                                   │
-│  key   │  multipleVariables                                                                                               │
-│  msg   │  Expected argument to contain "user" but received "name"                                                         │
-└────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+${formatTable([
+  [["info", "result"]],
+  [
+    ["file", tr("yaml/multipleFilesFolderExample/de-DE/one.yaml")],
+    ["key", "message.select"],
+    [
+      "msg",
+      'Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...',
+    ],
+  ],
+  [
+    ["file", tr("yaml/multipleFilesFolderExample/de-DE/three.yaml")],
+    ["key", "multipleVariables"],
+    ["msg", 'Expected argument to contain "user" but received "name"'],
+  ],
+])}
 
 `);
           done();

--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -359,27 +359,42 @@ ${formatTable([
 Source: en-US
 
 Found missing keys!
-┌──────────────────────────────────────────────────────────┬────────────────────────────────┐
-│ file                                                     │ key                            │
-├──────────────────────────────────────────────────────────┼────────────────────────────────┤
-│  translations/flattenExamples/de-de.json                 │  other.nested.three            │
-│  translations/flattenExamples/de-de.json                 │  other.nested.deep.more.final  │
-│  translations/multipleFilesFolderExample/de-DE/one.json  │  message.text-format           │
-│  translations/multipleFilesFolderExample/de-DE/two.json  │  test.drive.four               │
-└──────────────────────────────────────────────────────────┴────────────────────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [p("translations/flattenExamples/de-de.json"), "other.nested.three"],
+    [
+      p("translations/flattenExamples/de-de.json"),
+      "other.nested.deep.more.final",
+    ],
+    [
+      p("translations/multipleFilesFolderExample/de-DE/one.json"),
+      "message.text-format",
+    ],
+    [
+      p("translations/multipleFilesFolderExample/de-DE/two.json"),
+      "test.drive.four",
+    ],
+  ],
+])}
 
 Found invalid keys!
-┌────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ info   │ result                                                                                                           │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/multipleFilesFolderExample/de-DE/one.json                                                          │
-│  key   │  message.select                                                                                                  │
-│  msg   │  Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...  │
-├────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│  file  │  translations/multipleFilesFolderExample/de-DE/three.json                                                        │
-│  key   │  multipleVariables                                                                                               │
-│  msg   │  Expected argument to contain "user" but received "name"                                                         │
-└────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+${formatTable([
+  [["info", "result"]],
+  [
+    ["file", p("translations/multipleFilesFolderExample/de-DE/one.json")],
+    ["key", "message.select"],
+    [
+      "msg",
+      'Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...',
+    ],
+  ],
+  [
+    ["file", p("translations/multipleFilesFolderExample/de-DE/three.json")],
+    ["key", "multipleVariables"],
+    ["msg", 'Expected argument to contain "user" but received "name"'],
+  ],
+])}
 
 `);
           done();
@@ -396,25 +411,27 @@ Found invalid keys!
 Source: en-US
 
 Found missing keys!
-┌───────────────────────────────────────────┬────────────┐
-│ file                                      │ key        │
-├───────────────────────────────────────────┼────────────┤
-│  translations/messageExamples/de-de.json  │  richText  │
-│  translations/messageExamples/de-de.json  │  yo        │
-│  translations/messageExamples/de-de.json  │  nesting1  │
-│  translations/messageExamples/de-de.json  │  nesting2  │
-│  translations/messageExamples/de-de.json  │  nesting3  │
-│  translations/messageExamples/de-de.json  │  key1      │
-└───────────────────────────────────────────┴────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [p("translations/messageExamples/de-de.json"), "richText"],
+    [p("translations/messageExamples/de-de.json"), "yo"],
+    [p("translations/messageExamples/de-de.json"), "nesting1"],
+    [p("translations/messageExamples/de-de.json"), "nesting2"],
+    [p("translations/messageExamples/de-de.json"), "nesting3"],
+    [p("translations/messageExamples/de-de.json"), "key1"],
+  ],
+])}
 
 Found invalid keys!
-┌────────┬───────────────────────────────────────────┐
-│ info   │ result                                    │
-├────────┼───────────────────────────────────────────┤
-│  file  │  translations/messageExamples/de-de.json  │
-│  key   │  multipleVariables                        │
-│  msg   │  Unexpected date element                  │
-└────────┴───────────────────────────────────────────┘
+${formatTable([
+  [["info", "result"]],
+  [
+    ["file", p("translations/messageExamples/de-de.json")],
+    ["key", "multipleVariables"],
+    ["msg", "Unexpected date element"],
+  ],
+])}
 
 `);
           done();
@@ -431,25 +448,27 @@ Found invalid keys!
 Source: en-US
 
 Found missing keys!
-┌───────────────────────────────────────────┬────────────┐
-│ file                                      │ key        │
-├───────────────────────────────────────────┼────────────┤
-│  translations/messageExamples/de-de.json  │  richText  │
-│  translations/messageExamples/de-de.json  │  yo        │
-│  translations/messageExamples/de-de.json  │  nesting1  │
-│  translations/messageExamples/de-de.json  │  nesting2  │
-│  translations/messageExamples/de-de.json  │  nesting3  │
-│  translations/messageExamples/de-de.json  │  key1      │
-└───────────────────────────────────────────┴────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [p("translations/messageExamples/de-de.json"), "richText"],
+    [p("translations/messageExamples/de-de.json"), "yo"],
+    [p("translations/messageExamples/de-de.json"), "nesting1"],
+    [p("translations/messageExamples/de-de.json"), "nesting2"],
+    [p("translations/messageExamples/de-de.json"), "nesting3"],
+    [p("translations/messageExamples/de-de.json"), "key1"],
+  ],
+])}
 
 Found invalid keys!
-┌────────┬───────────────────────────────────────────┐
-│ info   │ result                                    │
-├────────┼───────────────────────────────────────────┤
-│  file  │  translations/messageExamples/de-de.json  │
-│  key   │  multipleVariables                        │
-│  msg   │  Unexpected date element                  │
-└────────┴───────────────────────────────────────────┘
+${formatTable([
+  [["info", "result"]],
+  [
+    ["file", p("translations/messageExamples/de-de.json")],
+    ["key", "multipleVariables"],
+    ["msg", "Unexpected date element"],
+  ],
+])}
 
 `);
           done();
@@ -489,19 +508,30 @@ No missing keys found!
 No invalid translations found!
 
 Found unused keys!
-┌──────────────────────────────────────────────────────────────────────┬──────────────────┐
-│ file                                                                 │ key              │
-├──────────────────────────────────────────────────────────────────────┼──────────────────┤
-│  translations/codeExamples/reacti18next/locales/en/translation.json  │  format.ebook    │
-│  translations/codeExamples/reacti18next/locales/en/translation.json  │  nonExistentKey  │
-└──────────────────────────────────────────────────────────────────────┴──────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [
+      p("translations/codeExamples/reacti18next/locales/en/translation.json"),
+      "format.ebook",
+    ],
+    [
+      p("translations/codeExamples/reacti18next/locales/en/translation.json"),
+      "nonExistentKey",
+    ],
+  ],
+])}
 
 Found undefined keys!
-┌──────────────────────────────────────────────────────┬────────────────────────────────┐
-│ file                                                 │ key                            │
-├──────────────────────────────────────────────────────┼────────────────────────────────┤
-│  translations/codeExamples/reacti18next/src/App.tsx  │  some.key.that.is.not.defined  │
-└──────────────────────────────────────────────────────┴────────────────────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [
+      p("translations/codeExamples/reacti18next/src/App.tsx"),
+      "some.key.that.is.not.defined",
+    ],
+  ],
+])}
 
 `);
           done();
@@ -523,20 +553,34 @@ No missing keys found!
 No invalid translations found!
 
 Found unused keys!
-┌──────────────────────────────────────────────────────────────────────┬──────────────────┐
-│ file                                                                 │ key              │
-├──────────────────────────────────────────────────────────────────────┼──────────────────┤
-│  translations/codeExamples/reacti18next/locales/en/translation.json  │  format.ebook    │
-│  translations/codeExamples/reacti18next/locales/en/translation.json  │  nonExistentKey  │
-└──────────────────────────────────────────────────────────────────────┴──────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [
+      p("translations/codeExamples/reacti18next/locales/en/translation.json"),
+      "format.ebook",
+    ],
+    [
+      p("translations/codeExamples/reacti18next/locales/en/translation.json"),
+      "nonExistentKey",
+    ],
+  ],
+])}
 
 Found undefined keys!
-┌───────────────────────────────────────────────────────────────────┬───────────────────────────────────┐
-│ file                                                              │ key                               │
-├───────────────────────────────────────────────────────────────────┼───────────────────────────────────┤
-│  translations/codeExamples/reacti18next/src/App.tsx               │  some.key.that.is.not.defined     │
-│  translations/codeExamples/reacti18next/secondSrcFolder/Main.tsx  │  another.key.that.is.not.defined  │
-└───────────────────────────────────────────────────────────────────┴───────────────────────────────────┘
+${formatTable([
+  [["file", "key"]],
+  [
+    [
+      p("translations/codeExamples/reacti18next/src/App.tsx"),
+      "some.key.that.is.not.defined",
+    ],
+    [
+      p("translations/codeExamples/reacti18next/secondSrcFolder/Main.tsx"),
+      "another.key.that.is.not.defined",
+    ],
+  ],
+])}
 
 `);
           done();

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -10,6 +10,7 @@ import { checkTranslations, checkUndefinedKeys, checkUnusedKeys } from "..";
 import {
   CheckOptions,
   Context,
+  formatTable,
   StandardReporter,
   standardReporter,
   summaryReporter,
@@ -324,7 +325,13 @@ const printTranslationResult = ({
     if (isSummary) {
       console.log(chalk.red(summaryReporter(getSummaryRows(missingKeys))));
     } else {
-      console.log(chalk.red(standardReporter(getStandardRows(missingKeys))));
+      const table = formatTable([
+        [["file", "key"]],
+        Object.entries(missingKeys).flatMap(([file, keys]) =>
+          keys.map((key) => [truncate(file), truncate(key)])
+        ),
+      ]);
+      console.log(chalk.red(table));
     }
   } else if (missingKeys) {
     console.log(chalk.green("\nNo missing keys found!"));
@@ -335,9 +342,18 @@ const printTranslationResult = ({
     if (isSummary) {
       console.log(chalk.red(summaryReporter(getSummaryRows(invalidKeys))));
     } else {
-      console.log(
-        chalk.red(standardReporter(getStandardRows(invalidKeys), true))
-      );
+      const table = formatTable([
+        [["info", "result"]],
+        ...Object.entries(invalidKeys).flatMap(([file, errors]) =>
+          errors.map(({ key, msg }) => [
+            ["file", truncate(file)],
+            ["key", truncate(key)],
+            ["msg", truncate(msg, 120)],
+          ])
+        ),
+      ]);
+
+      console.log(chalk.red(table));
     }
   } else if (invalidKeys) {
     console.log(chalk.green("\nNo invalid translations found!"));

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -325,12 +325,7 @@ const printTranslationResult = ({
     if (isSummary) {
       console.log(chalk.red(summaryReporter(getSummaryRows(missingKeys))));
     } else {
-      const table = formatTable([
-        [["file", "key"]],
-        Object.entries(missingKeys).flatMap(([file, keys]) =>
-          keys.map((key) => [truncate(file), truncate(key)])
-        ),
-      ]);
+      const table = formatCheckResultTable(missingKeys);
       console.log(chalk.red(table));
     }
   } else if (missingKeys) {
@@ -342,17 +337,7 @@ const printTranslationResult = ({
     if (isSummary) {
       console.log(chalk.red(summaryReporter(getSummaryRows(invalidKeys))));
     } else {
-      const table = formatTable([
-        [["info", "result"]],
-        ...Object.entries(invalidKeys).flatMap(([file, errors]) =>
-          errors.map(({ key, msg }) => [
-            ["file", truncate(file)],
-            ["key", truncate(key)],
-            ["msg", truncate(msg, 120)],
-          ])
-        ),
-      ]);
-
+      const table = formatInvalidTranslationsResultTable(invalidKeys);
       console.log(chalk.red(table));
     }
   } else if (invalidKeys) {
@@ -374,7 +359,7 @@ const printUnusedKeysResult = ({
     if (isSummary) {
       console.log(chalk.red(summaryReporter(getSummaryRows(unusedKeys))));
     } else {
-      console.log(chalk.red(standardReporter(getStandardRows(unusedKeys))));
+      console.log(chalk.red(formatCheckResultTable(unusedKeys)));
     }
   } else if (unusedKeys) {
     console.log(chalk.green("\nNo unused keys found!"));
@@ -395,12 +380,36 @@ const printUndefinedKeysResult = ({
     if (isSummary) {
       console.log(chalk.red(summaryReporter(getSummaryRows(undefinedKeys))));
     } else {
-      console.log(chalk.red(standardReporter(getStandardRows(undefinedKeys))));
+      console.log(chalk.red(formatCheckResultTable(undefinedKeys)));
     }
   } else if (undefinedKeys) {
     console.log(chalk.green("\nNo undefined keys found!"));
   }
 };
+
+function formatCheckResultTable(result: CheckResult) {
+  return formatTable([
+    [["file", "key"]],
+    Object.entries(result).flatMap(([file, keys]) =>
+      keys.map((key) => [truncate(file), truncate(key)])
+    ),
+  ]);
+}
+
+function formatInvalidTranslationsResultTable(
+  result: InvalidTranslationsResult
+) {
+  return formatTable([
+    [["info", "result"]],
+    ...Object.entries(result).flatMap(([file, errors]) =>
+      errors.map(({ key, msg }) => [
+        ["file", truncate(file)],
+        ["key", truncate(key)],
+        ["msg", truncate(msg, 120)],
+      ])
+    ),
+  ]);
+}
 
 const truncate = (chars: string, len = 80) =>
   chars.length > 80 ? `${chars.substring(0, len)}...` : chars;
@@ -415,32 +424,6 @@ const getSummaryRows = (
       file: truncate(file),
       total: keys.length,
     });
-  }
-  return formattedRows;
-};
-
-const getStandardRows = (
-  checkResult: CheckResult | InvalidTranslationsResult
-) => {
-  const formattedRows: StandardReporter[] = [];
-
-  for (const [file, keys] of Object.entries<
-    string[] | { key: string; msg: string }[]
-  >(checkResult)) {
-    for (const entry of keys) {
-      if (typeof entry === "object") {
-        formattedRows.push({
-          file: truncate(file),
-          key: truncate(entry.key),
-          msg: truncate(entry.msg, 120),
-        });
-      } else {
-        formattedRows.push({
-          file: truncate(file),
-          key: truncate(entry),
-        });
-      }
-    }
   }
   return formattedRows;
 };

--- a/src/errorReporters.ts
+++ b/src/errorReporters.ts
@@ -109,3 +109,51 @@ export const createVerticalTable = (input: unknown[]) => {
 
   return output.replace(/\n\n$/, "");
 };
+
+export function formatTable(rowGroups: string[][][], lineSep = "\n") {
+  // +2 for whitespace padding left and right
+  const padding = 2;
+  const colWidths: number[] = [];
+
+  for (const rows of rowGroups) {
+    for (const row of rows) {
+      for (let index = 0; index < row.length; ++index) {
+        colWidths[index] = Math.max(
+          colWidths[index] ?? 0,
+          row[index].length + padding
+        );
+      }
+    }
+  }
+  const lines: string[] = [];
+
+  lines.push(formatSeparatorRow(colWidths, "┌┬┐"));
+
+  for (const rows of rowGroups) {
+    for (const row of rows) {
+      lines.push(formatRow(row, colWidths));
+    }
+
+    lines.push(formatSeparatorRow(colWidths, "├┼┤"));
+  }
+
+  lines[lines.length - 1] = formatSeparatorRow(colWidths, "└┴┘");
+
+  return lines.join(lineSep);
+}
+
+function formatSeparatorRow(widths: number[], [left, middle, right]: string) {
+  return (
+    left + widths.map((width) => "".padEnd(width, "─")).join(middle) + right
+  );
+}
+
+function formatRow(values: string[], widths: number[]) {
+  return (
+    `│` +
+    values
+      .map((val, index) => ` ${val} `.padEnd(widths[index], " "))
+      .join("│") +
+    `│`
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { Context } from "./errorReporters";
 import { extract } from "@formatjs/cli-lib";
 import { extract as nextIntlExtract } from "./utils/nextIntlSrcParser";
 import fs from "fs";
+import path from "path";
 
 const ParseFormats = ["react-intl", "i18next", "next-intl"];
 
@@ -223,7 +224,7 @@ export const checkUndefinedKeys = async (
     format: "react-intl",
     checks: [],
   },
-  componentFunctions = []
+  componentFunctions: string[] = []
 ): Promise<CheckResult | undefined> => {
   if (!options.format || !ParseFormats.includes(options.format)) {
     return undefined;
@@ -259,8 +260,11 @@ const findUndefinedReactIntlKeys = async (
   let undefinedKeys: { [key: string]: string[] } = {};
   Object.entries(JSON.parse(extractedResult)).forEach(([key, meta]) => {
     if (!sourceKeys.has(key)) {
-      // @ts-ignore
-      const file = meta.file;
+      const data = meta as Record<PropertyKey, unknown>;
+      if (!("file" in data) || typeof data.file !== "string") {
+        return;
+      }
+      const file = path.normalize(data.file);
       if (!undefinedKeys[file]) {
         undefinedKeys[file] = [];
       }


### PR DESCRIPTION
Fix the cli tests on windows by dynamically formatting the expected output table and building normalized platform paths with `path.join`.

This also introduces a new table formatting utility. The summary reporter is still working with the old formatting logic though, but we probably want to streamline this to remove the old logic and associated workarounds entirely.

Stacked on top of #62 