### PR TITLE
Refactor tests to async/await

### DIFF
--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -22,24 +22,33 @@ function ymlMultiFolders(file: string) {
   return path.join("translations/yaml/multipleFoldersExample", file);
 }
 
+function execAsync(cmd: string) {
+  return new Promise<string>((resolve) => {
+    exec(cmd, (error, stdout, stderr) => {
+      resolve(stdout);
+    });
+  });
+}
+
 describe("CLI", () => {
   describe("JSON", () => {
-    it("should return the missing keys for single folder translations", (done) => {
-      exec(
-        "node dist/bin/index.js -s en-US -l translations/flattenExamples",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
+    it("should return the missing keys for single folder translations", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js -s en-US -l translations/flattenExamples"
+      );
 
-          const filePath = tr("flattenExamples/de-de.json");
-          const table = formatTable([
-            [["file", "key"]],
-            [
-              [filePath, "other.nested.three"],
-              [filePath, "other.nested.deep.more.final"],
-            ],
-          ]);
+      const result = stdout.split("Done")[0];
 
-          expect(result).toEqual(`i18n translations checker
+      const filePath = tr("flattenExamples/de-de.json");
+      const table = formatTable([
+        [["file", "key"]],
+        [
+          [filePath, "other.nested.three"],
+          [filePath, "other.nested.deep.more.final"],
+        ],
+      ]);
+
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -48,35 +57,33 @@ ${table}
 No invalid translations found!
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should return the missing/invalid keys for folder per locale with single file", (done) => {
-      exec(
-        "node dist/bin/index.js -l translations/folderExample/ -s en-US",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
+    it("should return the missing/invalid keys for folder per locale with single file", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js -l translations/folderExample/ -s en-US"
+      );
 
-          const missingKeysTable = formatTable([
-            [["file", "key"]],
-            [[tr("folderExample/de-DE/index.json"), "message.text-format"]],
-          ]);
+      const result = stdout.split("Done")[0];
 
-          const invalidKeysTable = formatTable([
-            [["info", "result"]],
-            [
-              ["file", tr("folderExample/de-DE/index.json")],
-              ["key", "message.select"],
-              [
-                "msg",
-                'Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...',
-              ],
-            ],
-          ]);
+      const missingKeysTable = formatTable([
+        [["file", "key"]],
+        [[tr("folderExample/de-DE/index.json"), "message.text-format"]],
+      ]);
 
-          expect(result).toEqual(`i18n translations checker
+      const invalidKeysTable = formatTable([
+        [["info", "result"]],
+        [
+          ["file", tr("folderExample/de-DE/index.json")],
+          ["key", "message.select"],
+          [
+            "msg",
+            'Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...',
+          ],
+        ],
+      ]);
+
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -86,45 +93,40 @@ Found invalid keys!
 ${invalidKeysTable}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should return the missing/invalid keys for folder per locale with multiple files", (done) => {
-      exec(
-        "node dist/bin/index.js -l translations/multipleFilesFolderExample/ -s en-US",
-        (_error, stdout, _stderr) => {
-          const missingKeysTable = formatTable([
-            [["file", "key"]],
-            [
-              [multiFiles("de-DE/one.json"), "message.text-format"],
-              [multiFiles("de-DE/two.json"), "test.drive.four"],
-            ],
-          ]);
+    it("should return the missing/invalid keys for folder per locale with multiple files", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js -l translations/multipleFilesFolderExample/ -s en-US"
+      );
 
-          const invalidKeysTable = formatTable([
-            [["info", "result"]],
-            [
-              ["file", multiFiles("de-DE/one.json")],
-              ["key", "message.select"],
-              [
-                "msg",
-                'Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...',
-              ],
-            ],
-            [
-              ["file", multiFiles("de-DE/three.json")],
-              ["key", "multipleVariables"],
-              [
-                "msg",
-                'Expected argument to contain "user" but received "name"  ',
-              ],
-            ],
-          ]);
+      const missingKeysTable = formatTable([
+        [["file", "key"]],
+        [
+          [multiFiles("de-DE/one.json"), "message.text-format"],
+          [multiFiles("de-DE/two.json"), "test.drive.four"],
+        ],
+      ]);
 
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+      const invalidKeysTable = formatTable([
+        [["info", "result"]],
+        [
+          ["file", multiFiles("de-DE/one.json")],
+          ["key", "message.select"],
+          [
+            "msg",
+            'Expected element of type "select" but received "argument", Unexpected date element, Unexpected date element...',
+          ],
+        ],
+        [
+          ["file", multiFiles("de-DE/three.json")],
+          ["key", "multipleVariables"],
+          ["msg", 'Expected argument to contain "user" but received "name"  '],
+        ],
+      ]);
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -134,17 +136,15 @@ Found invalid keys!
 ${invalidKeysTable}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should return the missing/invalid keys for folder containing multiple locale folders", (done) => {
-      exec(
-        "node dist/bin/index.js -l translations/multipleFoldersExample -s en-US",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should return the missing/invalid keys for folder containing multiple locale folders", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js -l translations/multipleFoldersExample -s en-US"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -190,17 +190,15 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should return the missing/invalid keys for multiple locale folders", (done) => {
-      exec(
-        "node dist/bin/index.js -l translations/multipleFoldersExample/spaceOne translations/multipleFoldersExample/spaceTwo -s en-US",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should return the missing/invalid keys for multiple locale folders", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js -l translations/multipleFoldersExample/spaceOne translations/multipleFoldersExample/spaceTwo -s en-US"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -246,17 +244,15 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should return the missing/invalid keys for all files in the provided locale folders", (done) => {
-      exec(
-        "node dist/bin/index.js --source en-US --locales translations/flattenExamples translations/messageExamples",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should return the missing/invalid keys for all files in the provided locale folders", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js --source en-US --locales translations/flattenExamples translations/messageExamples"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -285,17 +281,15 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should return the missing/invalid keys for all files with source matching folder and source matching file", (done) => {
-      exec(
-        "node dist/bin/index.js -l translations/multipleFilesFolderExample translations/flattenExamples -s en-US",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should return the missing/invalid keys for all files with source matching folder and source matching file", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js -l translations/multipleFilesFolderExample translations/flattenExamples -s en-US"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -328,17 +322,15 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should ignore the excluded file", (done) => {
-      exec(
-        "node dist/bin/index.js --source en-US --locales translations/flattenExamples translations/messageExamples --exclude translations/flattenExamples/de-de.json",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should ignore the excluded file", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js --source en-US --locales translations/flattenExamples translations/messageExamples --exclude translations/flattenExamples/de-de.json"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -365,17 +357,15 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should ignore the excluded folder", (done) => {
-      exec(
-        "node dist/bin/index.js --source en-US --locales translations/flattenExamples translations/messageExamples --exclude translations/flattenExamples/*",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should ignore the excluded folder", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js --source en-US --locales translations/flattenExamples translations/messageExamples --exclude translations/flattenExamples/*"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -402,17 +392,15 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should ignore the excluded multiple files", (done) => {
-      exec(
-        "node dist/bin/index.js --source en-US --locales translations/flattenExamples translations/messageExamples --exclude translations/flattenExamples/de-de.json translations/messageExamples/de-de.json",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should ignore the excluded multiple files", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js --source en-US --locales translations/flattenExamples translations/messageExamples --exclude translations/flattenExamples/de-de.json translations/messageExamples/de-de.json"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 No missing keys found!
@@ -420,17 +408,15 @@ No missing keys found!
 No invalid translations found!
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should find unused and undefined keys for react-i18next applications", (done) => {
-      exec(
-        "node dist/bin/index.js --source en --locales translations/codeExamples/reacti18next/locales -f i18next -u translations/codeExamples/reacti18next/src --parser-component-functions WrappedTransComponent",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should find unused and undefined keys for react-i18next applications", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js --source en --locales translations/codeExamples/reacti18next/locales -f i18next -u translations/codeExamples/reacti18next/src --parser-component-functions WrappedTransComponent"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en
 Selected format is: i18next
 
@@ -454,17 +440,15 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should find unused and undefined keys for react-i18next applications with multiple source folders", (done) => {
-      exec(
-        "node dist/bin/index.js --source en --locales translations/codeExamples/reacti18next/locales -f i18next -u translations/codeExamples/reacti18next/src translations/codeExamples/reacti18next/secondSrcFolder --parser-component-functions WrappedTransComponent",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should find unused and undefined keys for react-i18next applications with multiple source folders", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js --source en --locales translations/codeExamples/reacti18next/locales -f i18next -u translations/codeExamples/reacti18next/src translations/codeExamples/reacti18next/secondSrcFolder --parser-component-functions WrappedTransComponent"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en
 Selected format is: i18next
 
@@ -494,17 +478,15 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should find unused and undefined keys for react-intl applications", (done) => {
-      exec(
-        "node dist/bin/index.js --source en-US --locales translations/codeExamples/react-intl/locales -f react-intl -u translations/codeExamples/react-intl/src",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should find unused and undefined keys for react-intl applications", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js --source en-US --locales translations/codeExamples/react-intl/locales -f react-intl -u translations/codeExamples/react-intl/src"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 Selected format is: react-intl
 
@@ -528,17 +510,15 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should find unused and undefined keys for next-intl applications", (done) => {
-      exec(
-        "node dist/bin/index.js --source en --locales translations/codeExamples/next-intl/locales/ -f next-intl -u translations/codeExamples/next-intl/src",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should find unused and undefined keys for next-intl applications", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js --source en --locales translations/codeExamples/next-intl/locales/ -f next-intl -u translations/codeExamples/next-intl/src"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en
 Selected format is: next-intl
 
@@ -574,19 +554,17 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
   });
 
   describe("YAML", () => {
-    it("should return the missing keys for single folder translations", (done) => {
-      exec(
-        "node dist/bin/index.js -s en-US -l translations/yaml/flattenExamples",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should return the missing keys for single folder translations", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js -s en-US -l translations/yaml/flattenExamples"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -601,17 +579,15 @@ ${formatTable([
 No invalid translations found!
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should return the missing/invalid keys for folder per locale with single file", (done) => {
-      exec(
-        "node dist/bin/index.js -l translations/yaml/folderExample/ -s en-US",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should return the missing/invalid keys for folder per locale with single file", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js -l translations/yaml/folderExample/ -s en-US"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -634,17 +610,15 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should return the missing/invalid keys for folder per locale with multiple files", (done) => {
-      exec(
-        "node dist/bin/index.js -l translations/yaml/multipleFilesFolderExample/ -s en-US",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should return the missing/invalid keys for folder per locale with multiple files", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js -l translations/yaml/multipleFilesFolderExample/ -s en-US"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -678,17 +652,15 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should return the missing/invalid keys for folder containing multiple locale folders", (done) => {
-      exec(
-        "node dist/bin/index.js -l translations/yaml/multipleFoldersExample -s en-US",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should return the missing/invalid keys for folder containing multiple locale folders", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js -l translations/yaml/multipleFoldersExample -s en-US"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -734,17 +706,15 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should return the missing/invalid keys for multiple locale folders", (done) => {
-      exec(
-        "node dist/bin/index.js -l translations/yaml/multipleFoldersExample/spaceOne translations/yaml/multipleFoldersExample/spaceTwo -s en-US",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should return the missing/invalid keys for multiple locale folders", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js -l translations/yaml/multipleFoldersExample/spaceOne translations/yaml/multipleFoldersExample/spaceTwo -s en-US"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -790,17 +760,15 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should return the missing/invalid keys for all files in the provided locale folders", (done) => {
-      exec(
-        "node dist/bin/index.js --source en-US --locales translations/yaml/flattenExamples translations/yaml/messageExamples",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should return the missing/invalid keys for all files in the provided locale folders", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js --source en-US --locales translations/yaml/flattenExamples translations/yaml/messageExamples"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -829,17 +797,15 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
 
-    it("should return the missing/invalid keys for all files with source matching folder and source matching file", (done) => {
-      exec(
-        "node dist/bin/index.js -l translations/yaml/multipleFilesFolderExample translations/yaml/flattenExamples -s en-US",
-        (_error, stdout, _stderr) => {
-          const result = stdout.split("Done")[0];
-          expect(result).toEqual(`i18n translations checker
+    it("should return the missing/invalid keys for all files with source matching folder and source matching file", async () => {
+      const stdout = await execAsync(
+        "node dist/bin/index.js -l translations/yaml/multipleFilesFolderExample translations/yaml/flattenExamples -s en-US"
+      );
+
+      const result = stdout.split("Done")[0];
+      expect(result).toEqual(`i18n translations checker
 Source: en-US
 
 Found missing keys!
@@ -875,9 +841,6 @@ ${formatTable([
 ])}
 
 `);
-          done();
-        }
-      );
     });
   });
 });


### PR DESCRIPTION
Refactor to use async/await instead of the `done` callback.

The approach with the `done` callback had the issue that it does not work properly on assertion failure, resulting in spurious timeouts, since it never gets called unless the test is wrapped in a try-finally and `done` called in the finally block.

Stacked on top of #63 