### PR TITLE
Update i18next namespace handling

### DIFF
--- a/translations/codeExamples/reacti18next/locales/en/more.json
+++ b/translations/codeExamples/reacti18next/locales/en/more.json
@@ -1,0 +1,3 @@
+{
+  "hello": "hello"
+}

--- a/translations/codeExamples/reacti18next/locales/fr/more.json
+++ b/translations/codeExamples/reacti18next/locales/fr/more.json
@@ -1,0 +1,3 @@
+{
+  "hello": "hello"
+}

--- a/translations/codeExamples/reacti18next/src/App.tsx
+++ b/translations/codeExamples/reacti18next/src/App.tsx
@@ -47,13 +47,13 @@ export const I18NextExample = () => {
         <a href="some-link">here</a>!
       </WrappedTransComponent>
 
-      <WrappedTransComponent i18nKey="user.one" ns="one">
+      <WrappedTransComponent i18nKey="user.one" ns="translation">
         Welcome <b>{user}</b>!
       </WrappedTransComponent>
 
       <WrappedTransComponent
         i18nKey="some.deep.nested.key"
-        ns="two"
+        ns="translation"
         components={[
           <>
             <div />

--- a/translations/codeExamples/reacti18next/src/Content.tsx
+++ b/translations/codeExamples/reacti18next/src/Content.tsx
@@ -10,6 +10,8 @@ export const Content = () => {
       <Trans i18nKey="audio" />
       <Trans i18nKey="format.pdf" />
 
+      <p>{t("more:hello", "hello")}</p>
+
       {t("format.audio", "An audio format")}
     </p>
   );


### PR DESCRIPTION
Enables to find namespaces inside keys when checking for unused or undefined keys in a `i18next` codebase.

This enables to correctly compare keys containing a namespace:

```ts
<p>{t("some-namespace:hello", "hello")}</p>
```

Resolves #59 