### PR TITLE
Find promise.all next-intl getTranslations keys

### DIFF
--- a/src/utils/nextIntlSrcParser.test.ts
+++ b/src/utils/nextIntlSrcParser.test.ts
@@ -8,6 +8,10 @@ const counterFile = path.join(srcPath, 'Counter.tsx');
 const clientCounterFile = path.join(srcPath, 'ClientCounter.tsx');
 const nestedExampleFile = path.join(srcPath, 'NestedExample.tsx');
 const asyncExampleFile = path.join(srcPath, 'AsyncExample.tsx');
+const asyncPromiseAllExampleFile = path.join(
+  srcPath,
+  'AsyncPromiseAllExample.tsx'
+);
 const dynamicKeysExampleFile = path.join(srcPath, 'DynamicKeysExample.tsx');
 const strictTypesExample = path.join(srcPath, 'StrictTypesExample.tsx');
 const advancedExample = path.join(srcPath, 'AdvancedExample.tsx');
@@ -246,6 +250,27 @@ describe('nextIntlSrcParser', () => {
         meta: {
           file: asyncExampleFile,
           namespace: 'async.two',
+        },
+      },
+    ]);
+  });
+
+  it('should find all the async translation keys when using promise.all', () => {
+    const keys = extract([asyncPromiseAllExampleFile]);
+
+    expect(keys).toEqual([
+      {
+        key: 'asyncPromiseAll.subtitle',
+        meta: {
+          file: asyncPromiseAllExampleFile,
+          namespace: 'asyncPromiseAll',
+        },
+      },
+      {
+        key: 'asyncPromiseAll.title',
+        meta: {
+          file: asyncPromiseAllExampleFile,
+          namespace: 'asyncPromiseAll',
         },
       },
     ]);

--- a/translations/codeExamples/next-intl/locales/en/translation.json
+++ b/translations/codeExamples/next-intl/locales/en/translation.json
@@ -75,6 +75,10 @@
   "Async": {
     "title": "title"
   },
+  "asyncPromiseAll": {
+    "title": "title",
+    "subtitle": "subtitle"
+  },
   "testKeyWithoutNamespace": "testKeyWithoutNamespace",
   "notUsedKey": "notUsedKey",
   "deepNested": {

--- a/translations/codeExamples/next-intl/locales/fr/translation.json
+++ b/translations/codeExamples/next-intl/locales/fr/translation.json
@@ -75,6 +75,10 @@
   "Async": {
     "title": "title"
   },
+  "asyncPromiseAll": {
+    "title": "title",
+    "subtitle": "subtitle"
+  },
   "testKeyWithoutNamespace": "testKeyWithoutNamespace",
   "notUsedKey": "notUsedKey",
   "deepNested": {

--- a/translations/codeExamples/next-intl/src/AsyncPromiseAllExample.tsx
+++ b/translations/codeExamples/next-intl/src/AsyncPromiseAllExample.tsx
@@ -1,0 +1,16 @@
+// @ts-nocheck
+import { getTranslations } from 'next-intl/server';
+
+import { loadData } from './loadData';
+
+export const getData = async ({ id }) => {
+  const [data, t] = await Promise.all([
+    loadData(id),
+    getTranslations('asyncPromiseAll'),
+  ]);
+
+  return {
+    title: t('title', { id: data.id }),
+    subtitle: t('subtitle'),
+  };
+};


### PR DESCRIPTION
Enables to find all translation keys when calling `promise.all` and loading `getTranslations`.

```ts
import { getTranslations } from 'next-intl/server';

import { loadData } from './loadData';

export const getData = async ({ id }) => {
  const [data, t] = await Promise.all([
    loadData(id),
    getTranslations('asyncPromiseAll'),
  ]);

  return {
    title: t('title', { id: data.id }),
    subtitle: t('subtitle'),
  };
};
```

resolves #78 