### PR TITLE
Fix exit code 1 for successful unused checks

### DIFF
--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -565,6 +565,17 @@ ${formatTable([
 `);
     });
 
+    it('should exit with code 0 when no unused keys are found', async () => {
+      const cmd =
+        'node dist/bin/index.js --source en --locales translations/codeExamples/next-intl/locales/ -f next-intl -u translations/codeExamples/next-intl/src translations/codeExamples/next-intl/unused --only unused  -i "message.*"';
+
+      const result = await execAsyncWithExitCode(cmd);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('No unused keys found!');
+      expect(result.stdout).not.toContain('Found unused keys!');
+    });
+
     it('should exit with code 1 when unused keys are found', async () => {
       const cmd =
         'node dist/bin/index.js --source en --locales translations/codeExamples/next-intl/locales/ -f next-intl -u translations/codeExamples/next-intl/src --only unused';

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -303,7 +303,7 @@ const main = async () => {
     if (
       (result.missingKeys && Object.keys(result.missingKeys).length > 0) ||
       (result.invalidKeys && Object.keys(result.invalidKeys).length > 0) ||
-      (unusedKeyResult && Object.keys(unusedKeyResult).length > 0) ||
+      (unusedKeyResult && hasKeys(unusedKeyResult)) ||
       (undefinedKeyResult && Object.keys(undefinedKeyResult).length > 0)
     ) {
       exit(1);

--- a/translations/codeExamples/next-intl/unused/AddUnusedKeys.tsx
+++ b/translations/codeExamples/next-intl/unused/AddUnusedKeys.tsx
@@ -1,0 +1,15 @@
+// @ts-nocheck
+import { useTranslations } from 'next-intl';
+import NavigationLink from './NavigationLink';
+
+// We this for checking the CLI doesn't fail when there are no unused keys
+export default function AddUnusedKeys() {
+  const t = useTranslations();
+
+  return (
+    <div>
+      {t('notUsedKey')}
+      {t('message.plural')}
+    </div>
+  );
+}


### PR DESCRIPTION
#87 introduced a bug where a check with `unused` would fail even if there were no unused keys. Using `hasKeys(unusedKeyResult)` fixes this.