### PR TITLE
Introduce i18next parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ yarn i18n:check --locales translations/folderExamples -s en-US -i "some.path.to.
 
 ### --parser-component-functions
 
-When using the `--unused` option, there will be situations where the i18next-parser will not be able to find components that wrap a `Trans` component.The component names for i18next-parser to match should be provided via the `--parser-component-functions` option. This option should onlybe used to define additional names for matching, a by default `Trans` will always be matched.
+When using the `--unused` option, there will be situations where the i18next-parser will not be able to find components that wrap a `Trans` component. The component names for i18next-parser to match should be provided via the `--parser-component-functions` option. This option should only be used to define additional names for matching, as by default `Trans` will always be matched.
 
 ```bash
 yarn i18n:check --locales translations/i18NextMessageExamples -s en-US -f i18next

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "!dist/**/*.test.*"
   ],
   "dependencies": {
-    "@formatjs/cli-lib": "^6.6.6",
+    "@formatjs/cli-lib": "^8.2.3",
     "@formatjs/icu-messageformat-parser": "^2.11.4",
     "chalk": "^4.1.2",
     "commander": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "chalk": "^4.1.2",
     "commander": "^12.1.0",
     "glob": "12.0.0",
-    "i18next-parser": "^9.3.0",
     "js-yaml": "^4.1.1",
     "typescript": "^5.9.3"
   },
@@ -36,7 +35,6 @@
     "@eslint/js": "^9.39.1",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.19.1",
-    "@types/vinyl": "^2.0.12",
     "braces": "^3.0.3",
     "eslint": "^9.39.1",
     "globals": "^16.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,6 @@ importers:
       glob:
         specifier: 12.0.0
         version: 12.0.0
-      i18next-parser:
-        specifier: ^9.3.0
-        version: 9.3.0
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -46,9 +43,6 @@ importers:
       '@types/node':
         specifier: ^22.19.1
         version: 22.19.1
-      '@types/vinyl':
-        specifier: ^2.0.12
-        version: 2.0.12
       braces:
         specifier: ^3.0.3
         version: 3.0.3
@@ -69,10 +63,6 @@ importers:
         version: 4.0.10(@types/node@22.19.1)
 
 packages:
-
-  '@babel/runtime@7.28.4':
-    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
-    engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -336,10 +326,6 @@ packages:
       ts-jest:
         optional: true
 
-  '@gulpjs/to-absolute-glob@4.0.0':
-    resolution: {integrity: sha512-kjotm7XJrJ6v+7knhPaRgaT6q8F8K2jiafwYdNHLzmV0uGLuZY43FK6smNSHUPrhq5kX2slCUy+RGG/xGqmIKA==}
-    engines: {node: '>=10.13.0'}
-
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -505,9 +491,6 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/expect@1.20.4':
-    resolution: {integrity: sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==}
-
   '@types/fs-extra@11.0.4':
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
 
@@ -524,17 +507,8 @@ packages:
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
-  '@types/minimatch@3.0.5':
-    resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
-
   '@types/node@22.19.1':
     resolution: {integrity: sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==}
-
-  '@types/symlink-or-copy@1.2.2':
-    resolution: {integrity: sha512-MQ1AnmTLOncwEf9IVU+B2e4Hchrku5N67NkgcAHW0p3sdzPe0FNMANxEm6OJUzPniEQGkeT3OROLlCwZJLWFZA==}
-
-  '@types/vinyl@2.0.12':
-    resolution: {integrity: sha512-Sr2fYMBUVGYq8kj3UthXFAu5UN6ZW+rYr4NACjZQJvHvj+c8lYv0CahmZ2P/r7iUkN44gGUBwqxZkrKXYPb7cw==}
 
   '@typescript-eslint/eslint-plugin@8.47.0':
     resolution: {integrity: sha512-fe0rz9WJQ5t2iaLfdbDc9T80GJy0AeO453q8C3YCilnGozvOyCG5t+EZtg7j7D88+c3FipfP/x+wzGnh1xp8ZA==}
@@ -653,10 +627,6 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
-  anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -668,33 +638,8 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  b4a@1.7.3:
-    resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
-    peerDependencies:
-      react-native-b4a: '*'
-    peerDependenciesMeta:
-      react-native-b4a:
-        optional: true
-
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  bare-events@2.8.2:
-    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
-    peerDependencies:
-      bare-abort-controller: '*'
-    peerDependenciesMeta:
-      bare-abort-controller:
-        optional: true
-
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  bl@5.1.0:
-    resolution: {integrity: sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==}
-
-  boolbase@1.0.0:
-    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -705,24 +650,6 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-
-  broccoli-node-api@1.7.0:
-    resolution: {integrity: sha512-QIqLSVJWJUVOhclmkmypJJH9u9s/aWH4+FH6Q6Ju5l+Io4dtwqdPUNmDfw40o6sxhbZHhqGujDJuHTML1wG8Yw==}
-
-  broccoli-node-info@2.2.0:
-    resolution: {integrity: sha512-VabSGRpKIzpmC+r+tJueCE5h8k6vON7EIMMWu6d/FyPdtijwLQ7QvzShEw+m3mHoDzUaj/kiZsDYrS8X2adsBg==}
-    engines: {node: 8.* || >= 10.*}
-
-  broccoli-output-wrapper@3.2.5:
-    resolution: {integrity: sha512-bQAtwjSrF4Nu0CK0JOy5OZqw9t5U0zzv2555EA/cF8/a8SLDTIetk9UgrtMVw7qKLKdSpOZ2liZNeZZDaKgayw==}
-    engines: {node: 10.* || >= 12.*}
-
-  broccoli-plugin@4.0.7:
-    resolution: {integrity: sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==}
-    engines: {node: 10.* || >= 12.*}
-
-  buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -748,27 +675,12 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  cheerio-select@2.1.0:
-    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
-
-  cheerio@1.1.2:
-    resolution: {integrity: sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==}
-    engines: {node: '>=20.18.1'}
-
-  clone@2.1.2:
-    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
-    engines: {node: '>=0.8'}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  colors@1.4.0:
-    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
-    engines: {node: '>=0.1.90'}
 
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
@@ -777,34 +689,13 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  core-util-is@1.0.3:
-    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  css-select@5.2.2:
-    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
-
-  css-what@6.2.2:
-    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
-    engines: {node: '>= 6'}
-
   currently-unhandled@0.4.1:
     resolution: {integrity: sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==}
     engines: {node: '>=0.10.0'}
-
-  debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -825,19 +716,6 @@ packages:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
 
-  dom-serializer@2.0.0:
-    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
-
-  domelementtype@2.3.0:
-    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
-
-  domhandler@5.0.3:
-    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
-    engines: {node: '>= 4'}
-
-  domutils@3.2.2:
-    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
-
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -850,23 +728,6 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-
-  encoding-sniffer@0.2.1:
-    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
-
-  ensure-posix-path@1.1.1:
-    resolution: {integrity: sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==}
-
-  entities@4.5.0:
-    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
-    engines: {node: '>=0.12'}
-
-  entities@6.0.1:
-    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
-    engines: {node: '>=0.12'}
-
-  eol@0.9.1:
-    resolution: {integrity: sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -937,18 +798,12 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  events-universal@1.0.1:
-    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
-
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-fifo@1.3.2:
-    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -999,21 +854,6 @@ packages:
     resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
     engines: {node: '>=14.14'}
 
-  fs-extra@8.1.0:
-    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
-    engines: {node: '>=6 <7 || >=8'}
-
-  fs-merger@3.2.1:
-    resolution: {integrity: sha512-AN6sX12liy0JE7C2evclwoo0aCG3PFulLjrTLsJpWh/2mM+DinhpSGqYLbHBBbIW1PLRNcFhJG8Axtz8mQW3ug==}
-
-  fs-mkdirp-stream@2.0.1:
-    resolution: {integrity: sha512-UTOY+59K6IA94tec8Wjqm0FSh5OVudGNB0NL/P6fB3HiE3bYOY3VYBGijsnOHNkQSwC1FKkU77pmq7xp9CskLw==}
-    engines: {node: '>=10.13.0'}
-
-  fs-tree-diff@2.0.1:
-    resolution: {integrity: sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1036,10 +876,6 @@ packages:
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
-    engines: {node: '>=10.13.0'}
-
-  glob-stream@8.0.3:
-    resolution: {integrity: sha512-fqZVj22LtFJkHODT+M4N1RJQ3TjnnQhfE9GwZI8qXscYarnhpip70poMldRnP8ipQ/w0B621kOhfc53/J9bd/A==}
     engines: {node: '>=10.13.0'}
 
   glob@12.0.0:
@@ -1065,9 +901,6 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
-  gulp-sort@2.0.0:
-    resolution: {integrity: sha512-MyTel3FXOdh1qhw1yKhpimQrAmur9q1X0ZigLmCOxouQD+BD3za9/89O+HfbgBQvvh4igEbp0/PUWO+VqGYG1g==}
-
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1082,35 +915,6 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
-
-  heimdalljs-logger@0.1.10:
-    resolution: {integrity: sha512-pO++cJbhIufVI/fmB/u2Yty3KJD0TqNPecehFae0/eps0hkZ3b4Zc/PezUMOpYuHFQbA7FxHZxa305EhmjLj4g==}
-
-  heimdalljs@0.2.6:
-    resolution: {integrity: sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==}
-
-  htmlparser2@10.0.0:
-    resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
-
-  i18next-parser@9.3.0:
-    resolution: {integrity: sha512-VaQqk/6nLzTFx1MDiCZFtzZXKKyBV6Dv0cJMFM/hOt4/BWHWRgYafzYfVQRUzotwUwjqeNCprWnutzD/YAGczg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || ^22.0.0, npm: '>=6', yarn: '>=1'}
-    hasBin: true
-
-  i18next@24.2.3:
-    resolution: {integrity: sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==}
-    peerDependencies:
-      typescript: ^5
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
-    engines: {node: '>=0.10.0'}
-
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1128,9 +932,6 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1143,24 +944,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
-  is-negated-glob@1.0.0:
-    resolution: {integrity: sha512-czXVVn/QEmgvej1f50BZ648vUI+em0xqMq2Sn+QncCLN4zj1UAxlT+kw/6ggQTOaZPd1HqKQGEqbpQVtJucWug==}
-    engines: {node: '>=0.10.0'}
-
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-
-  is-plain-obj@4.1.0:
-    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
-    engines: {node: '>=12'}
-
-  is-valid-glob@1.0.0:
-    resolution: {integrity: sha512-AhiROmoEFDSsjx8hW+5sGwgKVIORcXnrlAx/R0ZSeaPw70Vw0CqkGBBhHGL58Uox2eXnU1AnvXJl1XlyedO5bA==}
-    engines: {node: '>=0.10.0'}
-
-  isarray@1.0.0:
-    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -1189,9 +975,6 @@ packages:
     resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
     engines: {node: '>= 0.4'}
 
-  jsonfile@4.0.0:
-    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
-
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
@@ -1201,17 +984,9 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  lead@4.0.0:
-    resolution: {integrity: sha512-DpMa59o5uGUWWjruMp71e6knmwKU3jRBBn1kjuLWN9EeIOxNeSAwvHf03WIl8g/ZMR2oSQC9ej3yeLBwdDc/pg==}
-    engines: {node: '>=10.13.0'}
-
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
-
-  lilconfig@3.1.3:
-    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
-    engines: {node: '>=14'}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -1230,10 +1005,6 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
-
-  matcher-collection@2.0.1:
-    resolution: {integrity: sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==}
-    engines: {node: 6.* || 8.* || >= 10.*}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1262,13 +1033,6 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mktemp@0.4.0:
-    resolution: {integrity: sha512-IXnMcJ6ZyTuhRmJSjzvHSRhlVPiN9Jwc6e59V0bEJ0ba6OBeX2L0E+mRN1QseeOF4mM+F1Rit6Nh7o+rl2Yn/A==}
-    engines: {node: '>0.9'}
-
-  ms@2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1280,27 +1044,9 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-
-  now-and-later@3.0.0:
-    resolution: {integrity: sha512-pGO4pzSdaxhWTGkfSfHx3hVzJVslFPwBp2Myq9MYN/ChfJZF87ochMAXnvz6/58RJSf5ik2q9tXprBBrk2cpcg==}
-    engines: {node: '>= 10.13.0'}
-
-  nth-check@2.1.1:
-    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
-
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1321,15 +1067,6 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
-  parse5-htmlparser2-tree-adapter@7.1.0:
-    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
-
-  parse5-parser-stream@7.1.2:
-    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
-
-  parse5@7.3.0:
-    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
-
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1337,9 +1074,6 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-
-  path-posix@1.0.0:
-    resolution: {integrity: sha512-1gJ0WpNIiYcQydgg3Ed8KzvIqTsDpNwq+cjBCssvBtuTWjEqY1AW+i+OepiEMqDCzyro9B2sLAe4RBPajMYFiA==}
 
   path-scurry@2.0.1:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
@@ -1372,13 +1106,6 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  process-nextick-args@2.0.1:
-    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-
-  promise-map-series@0.3.0:
-    resolution: {integrity: sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==}
-    engines: {node: 10.* || >= 12.*}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1386,63 +1113,21 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  quick-temp@0.1.8:
-    resolution: {integrity: sha512-YsmIFfD9j2zaFwJkzI6eMG7y0lQP7YeWzgtFgNl38pGWZBSXJooZbOWwkcRot7Vt0Fg9L23pX0tqWU3VvLDsiA==}
-
-  readable-stream@2.3.8:
-    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
-
-  readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
-
-  remove-trailing-separator@1.1.0:
-    resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
-
-  replace-ext@2.0.0:
-    resolution: {integrity: sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==}
-    engines: {node: '>= 10'}
-
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
-  resolve-options@2.0.0:
-    resolution: {integrity: sha512-/FopbmmFOQCfsCx77BRFdKOniglTiHumLgwvd6IDPihy1GKkadZbgQJBcTb2lMzSR1pndzd96b1nZrreZ7+9/A==}
-    engines: {node: '>= 10.13.0'}
-
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
-  rimraf@6.0.1:
-    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
-    engines: {node: 20 || >=22}
-    hasBin: true
 
   rollup@4.53.2:
     resolution: {integrity: sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rsvp@3.2.1:
-    resolution: {integrity: sha512-Rf4YVNYpKjZ6ASAmibcwTNciQ5Co5Ztq6iZPEykHpkoflnD/K5ryE/rHehFsTm4NJj8nKDhbi3eKBWGogmNnkg==}
-
-  rsvp@4.8.5:
-    resolution: {integrity: sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==}
-    engines: {node: 6.* || >= 7.*}
-
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
-
-  safe-buffer@5.1.2:
-    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
-
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
-  safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
@@ -1471,28 +1156,15 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  sort-keys@5.1.0:
-    resolution: {integrity: sha512-aSbHV0DaBcr7u0PVHXzM6NbZNAtrr9sF6+Qfs9UUVG7Ll3jQ6hHi8F/xqIIcn2rvIVbr0v/2zyjSdwSV47AgLQ==}
-    engines: {node: '>=12'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
-
-  sprintf-js@1.1.3:
-    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
-  stream-composer@1.0.2:
-    resolution: {integrity: sha512-bnBselmwfX5K10AH6L4c8+S5lgZMWI7ZYrz2rvYjCPB2DIMC4Ig8OpxGpNJSxRZ58oti7y1IcNvjBAz9vW5m4w==}
-
-  streamx@2.23.0:
-    resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1501,12 +1173,6 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
-
-  string_decoder@1.1.1:
-    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
-
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1523,18 +1189,6 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
-
-  symlink-or-copy@1.3.1:
-    resolution: {integrity: sha512-0K91MEXFpBUaywiwSSkmKjnGcasG/rVBXFLJz5DrgGabpYD6N+3yZrfD6uUIfpuTu65DZLHi7N8CizHc07BPZA==}
-
-  teex@1.0.1:
-    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
-
-  text-decoder@1.2.3:
-    resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
-
-  through2@2.0.5:
-    resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1553,10 +1207,6 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  to-through@3.0.0:
-    resolution: {integrity: sha512-y8MN937s/HVhEoBU1SxfHC+wxCHkV1a9gW8eAdTadYh/bGyesZIVcbjI+mSpFbSVwQici/XjBjuUyri1dnXwBw==}
-    engines: {node: '>=10.13.0'}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -1583,19 +1233,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  underscore.string@3.3.6:
-    resolution: {integrity: sha512-VoC83HWXmCrF6rgkyxS9GHv8W9Q5nhMKho+OadDJGzL2oDYbYEppBaCMH6pFlwLeqj2QS+hhkw2kpXkSdD1JxQ==}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici@7.16.0:
-    resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
-    engines: {node: '>=20.18.1'}
-
-  universalify@0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
-    engines: {node: '>= 4.0.0'}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -1603,29 +1242,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  value-or-function@4.0.0:
-    resolution: {integrity: sha512-aeVK81SIuT6aMJfNo9Vte8Dw0/FZINGBV8BfCraGtqVxIeLAEhJyoWs8SmvRVmXfGss2PmmOwZCuBPbZR+IYWg==}
-    engines: {node: '>= 10.13.0'}
-
-  vinyl-contents@2.0.0:
-    resolution: {integrity: sha512-cHq6NnGyi2pZ7xwdHSW1v4Jfnho4TEGtxZHw01cmnc8+i7jgR6bRnED/LbrKan/Q7CvVLbnvA5OepnhbpjBZ5Q==}
-    engines: {node: '>=10.13.0'}
-
-  vinyl-fs@4.0.2:
-    resolution: {integrity: sha512-XRFwBLLTl8lRAOYiBqxY279wY46tVxLaRhSwo3GzKEuLz1giffsOquWWboD/haGf5lx+JyTigCFfe7DWHoARIA==}
-    engines: {node: '>=10.13.0'}
-
-  vinyl-sourcemap@2.0.0:
-    resolution: {integrity: sha512-BAEvWxbBUXvlNoFQVFVHpybBbjW1r03WhohJzJDSfgrrK5xVYIDTan6xN14DlyImShgDRv2gl9qhM6irVMsV0Q==}
-    engines: {node: '>=10.13.0'}
-
-  vinyl@3.0.1:
-    resolution: {integrity: sha512-0QwqXteBNXgnLCdWdvPQBX6FXRHtIH3VhJPTd5Lwn28tJXc34YqSCWUmkOvtJHBmB3gGoPtrOKk3Ts8/kEZ9aA==}
-    engines: {node: '>=10.13.0'}
 
   vite@7.2.2:
     resolution: {integrity: sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==}
@@ -1701,18 +1317,6 @@ packages:
       jsdom:
         optional: true
 
-  walk-sync@2.2.0:
-    resolution: {integrity: sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==}
-    engines: {node: 8.* || >= 10.*}
-
-  whatwg-encoding@3.1.1:
-    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
-    engines: {node: '>=18'}
-
-  whatwg-mimetype@4.0.0:
-    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
-    engines: {node: '>=18'}
-
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1735,20 +1339,11 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  xtend@4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
 snapshots:
-
-  '@babel/runtime@7.28.4': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -1955,10 +1550,6 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.9.3
 
-  '@gulpjs/to-absolute-glob@4.0.0':
-    dependencies:
-      is-negated-glob: 1.0.0
-
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -2076,8 +1667,6 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/expect@1.20.4': {}
-
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
@@ -2095,18 +1684,9 @@ snapshots:
     dependencies:
       '@types/node': 22.19.1
 
-  '@types/minimatch@3.0.5': {}
-
   '@types/node@22.19.1':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/symlink-or-copy@1.2.2': {}
-
-  '@types/vinyl@2.0.12':
-    dependencies:
-      '@types/expect': 1.20.4
-      '@types/node': 22.19.1
 
   '@typescript-eslint/eslint-plugin@8.47.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(typescript@5.9.3)':
     dependencies:
@@ -2263,32 +1843,13 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  anymatch@3.1.3:
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
-
   argparse@2.0.1: {}
 
   array-find-index@1.0.2: {}
 
   assertion-error@2.0.1: {}
 
-  b4a@1.7.3: {}
-
   balanced-match@1.0.2: {}
-
-  bare-events@2.8.2: {}
-
-  base64-js@1.5.1: {}
-
-  bl@5.1.0:
-    dependencies:
-      buffer: 6.0.3
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
-  boolbase@1.0.0: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -2302,35 +1863,6 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  broccoli-node-api@1.7.0: {}
-
-  broccoli-node-info@2.2.0: {}
-
-  broccoli-output-wrapper@3.2.5:
-    dependencies:
-      fs-extra: 8.1.0
-      heimdalljs-logger: 0.1.10
-      symlink-or-copy: 1.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  broccoli-plugin@4.0.7:
-    dependencies:
-      broccoli-node-api: 1.7.0
-      broccoli-output-wrapper: 3.2.5
-      fs-merger: 3.2.1
-      promise-map-series: 0.3.0
-      quick-temp: 0.1.8
-      rimraf: 6.0.1
-      symlink-or-copy: 1.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  buffer@6.0.3:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -2358,46 +1890,15 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  cheerio-select@2.1.0:
-    dependencies:
-      boolbase: 1.0.0
-      css-select: 5.2.2
-      css-what: 6.2.2
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      domutils: 3.2.2
-
-  cheerio@1.1.2:
-    dependencies:
-      cheerio-select: 2.1.0
-      dom-serializer: 2.0.0
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      encoding-sniffer: 0.2.1
-      htmlparser2: 10.0.0
-      parse5: 7.3.0
-      parse5-htmlparser2-tree-adapter: 7.1.0
-      parse5-parser-stream: 7.1.2
-      undici: 7.16.0
-      whatwg-mimetype: 4.0.0
-
-  clone@2.1.2: {}
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
 
-  colors@1.4.0: {}
-
   commander@12.1.0: {}
 
   concat-map@0.0.1: {}
-
-  convert-source-map@2.0.0: {}
-
-  core-util-is@1.0.3: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2405,23 +1906,9 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-select@5.2.2:
-    dependencies:
-      boolbase: 1.0.0
-      css-what: 6.2.2
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      nth-check: 2.1.1
-
-  css-what@6.2.2: {}
-
   currently-unhandled@0.4.1:
     dependencies:
       array-find-index: 1.0.2
-
-  debug@2.6.9:
-    dependencies:
-      ms: 2.0.0
 
   debug@4.4.3:
     dependencies:
@@ -2437,24 +1924,6 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  dom-serializer@2.0.0:
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      entities: 4.5.0
-
-  domelementtype@2.3.0: {}
-
-  domhandler@5.0.3:
-    dependencies:
-      domelementtype: 2.3.0
-
-  domutils@3.2.2:
-    dependencies:
-      dom-serializer: 2.0.0
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -2466,19 +1935,6 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
-
-  encoding-sniffer@0.2.1:
-    dependencies:
-      iconv-lite: 0.6.3
-      whatwg-encoding: 3.1.1
-
-  ensure-posix-path@1.1.1: {}
-
-  entities@4.5.0: {}
-
-  entities@6.0.1: {}
-
-  eol@0.9.1: {}
 
   es-define-property@1.0.1: {}
 
@@ -2591,17 +2047,9 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  events-universal@1.0.1:
-    dependencies:
-      bare-events: 2.8.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-
   expect-type@1.2.2: {}
 
   fast-deep-equal@3.1.3: {}
-
-  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -2654,40 +2102,6 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fs-extra@8.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
-
-  fs-merger@3.2.1:
-    dependencies:
-      broccoli-node-api: 1.7.0
-      broccoli-node-info: 2.2.0
-      fs-extra: 8.1.0
-      fs-tree-diff: 2.0.1
-      walk-sync: 2.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  fs-mkdirp-stream@2.0.1:
-    dependencies:
-      graceful-fs: 4.2.11
-      streamx: 2.23.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
-  fs-tree-diff@2.0.1:
-    dependencies:
-      '@types/symlink-or-copy': 1.2.2
-      heimdalljs-logger: 0.1.10
-      object-assign: 4.1.1
-      path-posix: 1.0.0
-      symlink-or-copy: 1.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   fsevents@2.3.3:
     optional: true
 
@@ -2719,20 +2133,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob-stream@8.0.3:
-    dependencies:
-      '@gulpjs/to-absolute-glob': 4.0.0
-      anymatch: 3.1.3
-      fastq: 1.19.1
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      is-negated-glob: 1.0.0
-      normalize-path: 3.0.0
-      streamx: 2.23.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
   glob@12.0.0:
     dependencies:
       foreground-child: 3.3.1
@@ -2752,10 +2152,6 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  gulp-sort@2.0.0:
-    dependencies:
-      through2: 2.0.5
-
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
@@ -2768,60 +2164,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  heimdalljs-logger@0.1.10:
-    dependencies:
-      debug: 2.6.9
-      heimdalljs: 0.2.6
-    transitivePeerDependencies:
-      - supports-color
-
-  heimdalljs@0.2.6:
-    dependencies:
-      rsvp: 3.2.1
-
-  htmlparser2@10.0.0:
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      entities: 6.0.1
-
-  i18next-parser@9.3.0:
-    dependencies:
-      '@babel/runtime': 7.28.4
-      broccoli-plugin: 4.0.7
-      cheerio: 1.1.2
-      colors: 1.4.0
-      commander: 12.1.0
-      eol: 0.9.1
-      esbuild: 0.25.12
-      fs-extra: 11.3.2
-      gulp-sort: 2.0.0
-      i18next: 24.2.3(typescript@5.9.3)
-      js-yaml: 4.1.1
-      lilconfig: 3.1.3
-      rsvp: 4.8.5
-      sort-keys: 5.1.0
-      typescript: 5.9.3
-      vinyl: 3.0.1
-      vinyl-fs: 4.0.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-      - supports-color
-
-  i18next@24.2.3(typescript@5.9.3):
-    dependencies:
-      '@babel/runtime': 7.28.4
-    optionalDependencies:
-      typescript: 5.9.3
-
-  iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: 2.1.2
-
-  ieee754@1.2.1: {}
-
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -2833,8 +2175,6 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  inherits@2.0.4: {}
-
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -2843,15 +2183,7 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
-  is-negated-glob@1.0.0: {}
-
   is-number@7.0.0: {}
-
-  is-plain-obj@4.1.0: {}
-
-  is-valid-glob@1.0.0: {}
-
-  isarray@1.0.0: {}
 
   isarray@2.0.5: {}
 
@@ -2879,10 +2211,6 @@ snapshots:
       jsonify: 0.0.1
       object-keys: 1.1.1
 
-  jsonfile@4.0.0:
-    optionalDependencies:
-      graceful-fs: 4.2.11
-
   jsonfile@6.2.0:
     dependencies:
       universalify: 2.0.1
@@ -2895,14 +2223,10 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  lead@4.0.0: {}
-
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
-
-  lilconfig@3.1.3: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -2920,11 +2244,6 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  matcher-collection@2.0.1:
-    dependencies:
-      '@types/minimatch': 3.0.5
-      minimatch: 3.1.2
 
   math-intrinsics@1.1.0: {}
 
@@ -2949,33 +2268,13 @@ snapshots:
 
   minipass@7.1.2: {}
 
-  mktemp@0.4.0: {}
-
-  ms@2.0.0: {}
-
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
 
-  normalize-path@3.0.0: {}
-
-  now-and-later@3.0.0:
-    dependencies:
-      once: 1.4.0
-
-  nth-check@2.1.1:
-    dependencies:
-      boolbase: 1.0.0
-
-  object-assign@4.1.1: {}
-
   object-keys@1.1.1: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -3000,24 +2299,9 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
-  parse5-htmlparser2-tree-adapter@7.1.0:
-    dependencies:
-      domhandler: 5.0.3
-      parse5: 7.3.0
-
-  parse5-parser-stream@7.1.2:
-    dependencies:
-      parse5: 7.3.0
-
-  parse5@7.3.0:
-    dependencies:
-      entities: 6.0.1
-
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
-
-  path-posix@1.0.0: {}
 
   path-scurry@2.0.1:
     dependencies:
@@ -3042,52 +2326,13 @@ snapshots:
 
   prettier@3.6.2: {}
 
-  process-nextick-args@2.0.1: {}
-
-  promise-map-series@0.3.0: {}
-
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
 
-  quick-temp@0.1.8:
-    dependencies:
-      mktemp: 0.4.0
-      rimraf: 6.0.1
-      underscore.string: 3.3.6
-
-  readable-stream@2.3.8:
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 1.0.0
-      process-nextick-args: 2.0.1
-      safe-buffer: 5.1.2
-      string_decoder: 1.1.1
-      util-deprecate: 1.0.2
-
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
-
-  remove-trailing-separator@1.1.0: {}
-
-  replace-ext@2.0.0: {}
-
   resolve-from@4.0.0: {}
 
-  resolve-options@2.0.0:
-    dependencies:
-      value-or-function: 4.0.0
-
   reusify@1.1.0: {}
-
-  rimraf@6.0.1:
-    dependencies:
-      glob: 12.0.0
-      package-json-from-dist: 1.0.1
 
   rollup@4.53.2:
     dependencies:
@@ -3117,19 +2362,9 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.53.2
       fsevents: 2.3.3
 
-  rsvp@3.2.1: {}
-
-  rsvp@4.8.5: {}
-
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-
-  safe-buffer@5.1.2: {}
-
-  safe-buffer@5.2.1: {}
-
-  safer-buffer@2.1.2: {}
 
   semver@7.7.3: {}
 
@@ -3154,33 +2389,11 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  sort-keys@5.1.0:
-    dependencies:
-      is-plain-obj: 4.1.0
-
   source-map-js@1.2.1: {}
-
-  sprintf-js@1.1.3: {}
 
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
-
-  stream-composer@1.0.2:
-    dependencies:
-      streamx: 2.23.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
-  streamx@2.23.0:
-    dependencies:
-      events-universal: 1.0.1
-      fast-fifo: 1.3.2
-      text-decoder: 1.2.3
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
 
   string-width@4.2.3:
     dependencies:
@@ -3193,14 +2406,6 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.2
-
-  string_decoder@1.1.1:
-    dependencies:
-      safe-buffer: 5.1.2
-
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -3216,26 +2421,6 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  symlink-or-copy@1.3.1: {}
-
-  teex@1.0.1:
-    dependencies:
-      streamx: 2.23.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
-  text-decoder@1.2.3:
-    dependencies:
-      b4a: 1.7.3
-    transitivePeerDependencies:
-      - react-native-b4a
-
-  through2@2.0.5:
-    dependencies:
-      readable-stream: 2.3.8
-      xtend: 4.0.2
-
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -3250,13 +2435,6 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-
-  to-through@3.0.0:
-    dependencies:
-      streamx: 2.23.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
 
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
@@ -3281,76 +2459,13 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  underscore.string@3.3.6:
-    dependencies:
-      sprintf-js: 1.1.3
-      util-deprecate: 1.0.2
-
   undici-types@6.21.0: {}
-
-  undici@7.16.0: {}
-
-  universalify@0.1.2: {}
 
   universalify@2.0.1: {}
 
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  util-deprecate@1.0.2: {}
-
-  value-or-function@4.0.0: {}
-
-  vinyl-contents@2.0.0:
-    dependencies:
-      bl: 5.1.0
-      vinyl: 3.0.1
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
-  vinyl-fs@4.0.2:
-    dependencies:
-      fs-mkdirp-stream: 2.0.1
-      glob-stream: 8.0.3
-      graceful-fs: 4.2.11
-      iconv-lite: 0.6.3
-      is-valid-glob: 1.0.0
-      lead: 4.0.0
-      normalize-path: 3.0.0
-      resolve-options: 2.0.0
-      stream-composer: 1.0.2
-      streamx: 2.23.0
-      to-through: 3.0.0
-      value-or-function: 4.0.0
-      vinyl: 3.0.1
-      vinyl-sourcemap: 2.0.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
-  vinyl-sourcemap@2.0.0:
-    dependencies:
-      convert-source-map: 2.0.0
-      graceful-fs: 4.2.11
-      now-and-later: 3.0.0
-      streamx: 2.23.0
-      vinyl: 3.0.1
-      vinyl-contents: 2.0.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
-  vinyl@3.0.1:
-    dependencies:
-      clone: 2.1.2
-      remove-trailing-separator: 1.1.0
-      replace-ext: 2.0.0
-      teex: 1.0.1
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
 
   vite@7.2.2(@types/node@22.19.1):
     dependencies:
@@ -3402,19 +2517,6 @@ snapshots:
       - tsx
       - yaml
 
-  walk-sync@2.2.0:
-    dependencies:
-      '@types/minimatch': 3.0.5
-      ensure-posix-path: 1.1.1
-      matcher-collection: 2.0.1
-      minimatch: 3.1.2
-
-  whatwg-encoding@3.1.1:
-    dependencies:
-      iconv-lite: 0.6.3
-
-  whatwg-mimetype@4.0.0: {}
-
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -3437,9 +2539,5 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.1.2
-
-  wrappy@1.0.2: {}
-
-  xtend@4.0.2: {}
 
   yocto-queue@0.1.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     dependencies:
       '@formatjs/cli-lib':
-        specifier: ^6.6.6
-        version: 6.6.6
+        specifier: ^8.2.3
+        version: 8.2.3
       '@formatjs/icu-messageformat-parser':
         specifier: ^2.11.4
         version: 2.11.4
@@ -258,18 +258,17 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@formatjs/cli-lib@6.6.6':
-    resolution: {integrity: sha512-yWcW2fJB7wLblOPED+1NfaUU0dHBt/UZSsw774lh/oxKrr+rOfFTHciqTMif1H533mRcxkPtIZf/WdPsgzqgXA==}
+  '@formatjs/cli-lib@8.2.3':
+    resolution: {integrity: sha512-W9ou/iV5U3i5R4JaSqP+lRb2JFTHu1yfiwplecMhXfQ+BrdOVCuyOXezfzkYKBw0VhdkzmWvSS8PlYn6ftY02w==}
     engines: {node: '>= 16'}
     peerDependencies:
-      '@glimmer/env': ^0.1.7
-      '@glimmer/reference': ^0.91.1 || ^0.92.0
-      '@glimmer/syntax': ^0.92.0
-      '@glimmer/validator': ^0.92.0
-      '@vue/compiler-core': ^3.4.0
-      content-tag: ^2.0.1
-      ember-template-recast: ^6.1.4
-      vue: ^3.4.0
+      '@glimmer/env': '*'
+      '@glimmer/reference': '*'
+      '@glimmer/syntax': ^0.84.3 || ^0.95.0
+      '@glimmer/validator': '*'
+      '@vue/compiler-core': 3.5.27
+      content-tag: ^4.1.0
+      vue: 3.5.27
     peerDependenciesMeta:
       '@glimmer/env':
         optional: true
@@ -283,45 +282,43 @@ packages:
         optional: true
       content-tag:
         optional: true
-      ember-template-recast:
-        optional: true
       vue:
         optional: true
-
-  '@formatjs/ecma402-abstract@2.2.4':
-    resolution: {integrity: sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==}
 
   '@formatjs/ecma402-abstract@2.3.6':
     resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
 
-  '@formatjs/fast-memoize@2.2.3':
-    resolution: {integrity: sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==}
+  '@formatjs/ecma402-abstract@3.1.1':
+    resolution: {integrity: sha512-jhZbTwda+2tcNrs4kKvxrPLPjx8QsBCLCUgrrJ/S+G9YrGHWLhAyFMMBHJBnBoOwuLHd7L14FgYudviKaxkO2Q==}
 
   '@formatjs/fast-memoize@2.2.7':
     resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
 
+  '@formatjs/fast-memoize@3.1.0':
+    resolution: {integrity: sha512-b5mvSWCI+XVKiz5WhnBCY3RJ4ZwfjAidU0yVlKa3d3MSgKmH1hC3tBGEAtYyN5mqL7N0G5x0BOUYyO8CEupWgg==}
+
   '@formatjs/icu-messageformat-parser@2.11.4':
     resolution: {integrity: sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==}
 
-  '@formatjs/icu-messageformat-parser@2.9.4':
-    resolution: {integrity: sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==}
+  '@formatjs/icu-messageformat-parser@3.5.1':
+    resolution: {integrity: sha512-sSDmSvmmoVQ92XqWb499KrIhv/vLisJU8ITFrx7T7NZHUmMY7EL9xgRowAosaljhqnj/5iufG24QrdzB6X3ItA==}
 
   '@formatjs/icu-skeleton-parser@1.8.16':
     resolution: {integrity: sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==}
 
-  '@formatjs/icu-skeleton-parser@1.8.8':
-    resolution: {integrity: sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==}
-
-  '@formatjs/intl-localematcher@0.5.8':
-    resolution: {integrity: sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==}
+  '@formatjs/icu-skeleton-parser@2.1.1':
+    resolution: {integrity: sha512-PSFABlcNefjI6yyk8f7nyX1DC7NHmq6WaCHZLySEXBrXuLOB2f935YsnzuPjlz+ibhb9yWTdPeVX1OVcj24w2Q==}
 
   '@formatjs/intl-localematcher@0.6.2':
     resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
 
-  '@formatjs/ts-transformer@3.13.23':
-    resolution: {integrity: sha512-9ufpij2uHlc/yzb2WDOswaslTQQ7nOIE7aDLWErmc7Kpm5uPU6MihSuEa//DVoNoOD+fywYkbqsZnDjvXeLuAQ==}
+  '@formatjs/intl-localematcher@0.8.1':
+    resolution: {integrity: sha512-xwEuwQFdtSq1UKtQnyTZWC+eHdv7Uygoa+H2k/9uzBVQjDyp9r20LNDNKedWXll7FssT3GRHvqsdJGYSUWqYFA==}
+
+  '@formatjs/ts-transformer@4.3.3':
+    resolution: {integrity: sha512-jXh2NRP1wwYt57KAHaMiI8qZ6m6HFkPSOuAoVbOIzI+cP4++X1CVAtoQhTdEAyHhn04T4IyMdsFIGjYvtTZSAA==}
     peerDependencies:
-      ts-jest: '>=27'
+      ts-jest: ^29
     peerDependenciesMeta:
       ts-jest:
         optional: true
@@ -500,15 +497,14 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/json-stable-stringify@1.2.0':
-    resolution: {integrity: sha512-PEHY3ohqolHqAzDyB1+31tFaAMnoLN7x/JgdcGmNZ2uvtEJ6rlFCUYNQc0Xe754xxCYLNGZbLUGydSE6tS4S9A==}
-    deprecated: This is a stub types definition. json-stable-stringify provides its own type definitions, so you do not need this installed.
-
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
   '@types/node@22.19.1':
     resolution: {integrity: sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==}
+
+  '@types/node@22.19.11':
+    resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
 
   '@typescript-eslint/eslint-plugin@8.47.0':
     resolution: {integrity: sha512-fe0rz9WJQ5t2iaLfdbDc9T80GJy0AeO453q8C3YCilnGozvOyCG5t+EZtg7j7D88+c3FipfP/x+wzGnh1xp8ZA==}
@@ -686,6 +682,10 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -850,8 +850,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  fs-extra@11.3.2:
-    resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
+  fs-extra@11.3.3:
+    resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
     engines: {node: '>=14.14'}
 
   fsevents@2.3.3:
@@ -1469,31 +1469,24 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@formatjs/cli-lib@6.6.6':
+  '@formatjs/cli-lib@8.2.3':
     dependencies:
-      '@formatjs/icu-messageformat-parser': 2.9.4
-      '@formatjs/icu-skeleton-parser': 1.8.8
-      '@formatjs/ts-transformer': 3.13.23
+      '@formatjs/icu-messageformat-parser': 3.5.1
+      '@formatjs/icu-skeleton-parser': 2.1.1
+      '@formatjs/ts-transformer': 4.3.3
       '@types/estree': 1.0.8
       '@types/fs-extra': 11.0.4
-      '@types/json-stable-stringify': 1.2.0
-      '@types/node': 22.19.1
+      '@types/node': 22.19.11
       chalk: 4.1.2
-      commander: 12.1.0
+      commander: 14.0.3
       fast-glob: 3.3.3
-      fs-extra: 11.3.2
+      fs-extra: 11.3.3
       json-stable-stringify: 1.3.0
       loud-rejection: 2.2.0
       tslib: 2.8.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - ts-jest
-
-  '@formatjs/ecma402-abstract@2.2.4':
-    dependencies:
-      '@formatjs/fast-memoize': 2.2.3
-      '@formatjs/intl-localematcher': 0.5.8
-      tslib: 2.8.1
 
   '@formatjs/ecma402-abstract@2.3.6':
     dependencies:
@@ -1502,11 +1495,18 @@ snapshots:
       decimal.js: 10.6.0
       tslib: 2.8.1
 
-  '@formatjs/fast-memoize@2.2.3':
+  '@formatjs/ecma402-abstract@3.1.1':
     dependencies:
+      '@formatjs/fast-memoize': 3.1.0
+      '@formatjs/intl-localematcher': 0.8.1
+      decimal.js: 10.6.0
       tslib: 2.8.1
 
   '@formatjs/fast-memoize@2.2.7':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/fast-memoize@3.1.0':
     dependencies:
       tslib: 2.8.1
 
@@ -1516,10 +1516,10 @@ snapshots:
       '@formatjs/icu-skeleton-parser': 1.8.16
       tslib: 2.8.1
 
-  '@formatjs/icu-messageformat-parser@2.9.4':
+  '@formatjs/icu-messageformat-parser@3.5.1':
     dependencies:
-      '@formatjs/ecma402-abstract': 2.2.4
-      '@formatjs/icu-skeleton-parser': 1.8.8
+      '@formatjs/ecma402-abstract': 3.1.1
+      '@formatjs/icu-skeleton-parser': 2.1.1
       tslib: 2.8.1
 
   '@formatjs/icu-skeleton-parser@1.8.16':
@@ -1527,24 +1527,24 @@ snapshots:
       '@formatjs/ecma402-abstract': 2.3.6
       tslib: 2.8.1
 
-  '@formatjs/icu-skeleton-parser@1.8.8':
+  '@formatjs/icu-skeleton-parser@2.1.1':
     dependencies:
-      '@formatjs/ecma402-abstract': 2.2.4
-      tslib: 2.8.1
-
-  '@formatjs/intl-localematcher@0.5.8':
-    dependencies:
+      '@formatjs/ecma402-abstract': 3.1.1
       tslib: 2.8.1
 
   '@formatjs/intl-localematcher@0.6.2':
     dependencies:
       tslib: 2.8.1
 
-  '@formatjs/ts-transformer@3.13.23':
+  '@formatjs/intl-localematcher@0.8.1':
     dependencies:
-      '@formatjs/icu-messageformat-parser': 2.9.4
-      '@types/json-stable-stringify': 1.2.0
-      '@types/node': 22.19.1
+      '@formatjs/fast-memoize': 3.1.0
+      tslib: 2.8.1
+
+  '@formatjs/ts-transformer@4.3.3':
+    dependencies:
+      '@formatjs/icu-messageformat-parser': 3.5.1
+      '@types/node': 22.19.11
       chalk: 4.1.2
       json-stable-stringify: 1.3.0
       tslib: 2.8.1
@@ -1670,21 +1670,21 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 22.19.1
+      '@types/node': 22.19.11
 
   '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/json-stable-stringify@1.2.0':
-    dependencies:
-      json-stable-stringify: 1.3.0
-
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.11
 
   '@types/node@22.19.1':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/node@22.19.11':
     dependencies:
       undici-types: 6.21.0
 
@@ -1898,6 +1898,8 @@ snapshots:
 
   commander@12.1.0: {}
 
+  commander@14.0.3: {}
+
   concat-map@0.0.1: {}
 
   cross-spawn@7.0.6:
@@ -2096,7 +2098,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fs-extra@11.3.2:
+  fs-extra@11.3.3:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0

--- a/src/utils/i18NextSrcParser.test.ts
+++ b/src/utils/i18NextSrcParser.test.ts
@@ -1,0 +1,870 @@
+/**
+ *
+ * To ensure full compatability with the deprecated `i18next-parser`
+ * the internal `i18NextSrcParser`is tested against the `i18next-parser` lexer tests.
+ *
+ * Tests taken from:
+ *  javascript-lexer:https://github.com/i18next/i18next-parser/blob/master/test/lexers/javascript-lexer.test.js
+ *  jsx-lexer: https://github.com/i18next/i18next-parser/blob/master/test/lexers/jsx-lexer.test.js
+ *
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getKeys } from './i18NextSrcParser';
+
+describe('getKeys', () => {
+  describe('supports JSX', () => {
+    describe('<Interpolate>', () => {
+      it('extracts keys from i18nKey attributes', () => {
+        const content = '<Interpolate i18nKey="first" />';
+        expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'first' }]);
+      });
+    });
+
+    describe('<Translation>', () => {
+      it('extracts keys from render prop', () => {
+        const content = `<Translation>{(t) => <>{t("first", "Main")}{t("second")}</>}</Translation>`;
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { defaultValue: 'Main', key: 'first' },
+          { key: 'second' },
+        ]);
+      });
+
+      it('sets ns (namespace) for expressions within render prop', () => {
+        const content = `<Translation ns="foo">{(t) => t("first")}</Translation>`;
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { key: 'first', namespace: 'foo' },
+        ]);
+      });
+    });
+
+    describe('<Trans>', () => {
+      it('extracts keys from i18nKey attributes from closing tags', () => {
+        const content = '<Trans i18nKey="first" count={count}>Yo</Trans>';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { key: 'first', defaultValue: 'Yo', count: '{count}' },
+        ]);
+      });
+
+      it('extracts default value from string literal `defaults` prop', () => {
+        const content =
+          '<Trans i18nKey="first" defaults="test-value">should be ignored</Trans>';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { key: 'first', defaultValue: 'test-value' },
+        ]);
+      });
+
+      it('extracts default value from interpolated expression statement `defaults` prop', () => {
+        const content =
+          '<Trans i18nKey="first" defaults={"test-value"}>should be ignored</Trans>';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { key: 'first', defaultValue: 'test-value' },
+        ]);
+      });
+
+      it('extracts keys from user-defined key attributes from closing tags', () => {
+        const content = '<Trans myIntlKey="first" count={count}>Yo</Trans>';
+        expect(getKeys('test.jsx', { attr: 'myIntlKey' }, content)).toEqual([
+          { key: 'first', defaultValue: 'Yo', count: '{count}' },
+        ]);
+      });
+
+      it('extracts keys from i18nKey attributes from self-closing tags', () => {
+        const content = '<Trans i18nKey="first" count={count} />';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { key: 'first', count: '{count}' },
+        ]);
+      });
+
+      it('extracts keys from user-defined key attributes from self-closing tags', () => {
+        const content = '<Trans myIntlKey="first" count={count} />';
+        expect(getKeys('test.jsx', { attr: 'myIntlKey' }, content)).toEqual([
+          { key: 'first', count: '{count}' },
+        ]);
+      });
+
+      it('extracts custom attributes', () => {
+        const content = '<Trans customAttribute="Youpi">Yo</Trans>';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { key: 'Yo', defaultValue: 'Yo', customAttribute: 'Youpi' },
+        ]);
+      });
+
+      it('extracts boolean attributes', () => {
+        const content =
+          '<Trans ordinal customTrue={true} customFalse={false}>Yo</Trans>';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          {
+            key: 'Yo',
+            defaultValue: 'Yo',
+            ordinal: true,
+            customTrue: true,
+            customFalse: false,
+          },
+        ]);
+      });
+
+      it('extracts keys from Trans elements without an i18nKey', () => {
+        const content = '<Trans count={count}>Yo</Trans>';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { key: 'Yo', defaultValue: 'Yo', count: '{count}' },
+        ]);
+      });
+
+      it('extracts keys from Trans elements without an i18nKey, but with a defaults prop', () => {
+        const content = '<Trans defaults="Steve">{{ name }}</Trans>';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { key: '{{name}}', defaultValue: 'Steve' },
+        ]);
+      });
+
+      it('extracts keys from Trans elements without an i18nKey, with defaults, and without children', () => {
+        // Based on https://react.i18next.com/latest/trans-component#alternative-usage-components-array
+        const content = `
+<Trans
+  defaults="hello <0>{{what}}</0>"
+  values={{
+    what: "world"
+  }}
+  components={[<strong />]}
+/>
+`.trim();
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          {
+            key: 'hello <0>{{what}}</0>',
+            defaultValue: 'hello <0>{{what}}</0>',
+            components: '{[<strong />]}',
+            values: '{{ what: "world" }}',
+          },
+        ]);
+      });
+
+      it('extracts keys from Trans elements and ignores values of expressions and spaces', () => {
+        const content = '<Trans count={count}>{{ key: property }}</Trans>';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { key: '{{key}}', defaultValue: '{{key}}', count: '{count}' },
+        ]);
+      });
+
+      it('extracts formatted interpolations correctly', () => {
+        const content =
+          '<Trans count={count}>{{ key: property, format: "number" }}</Trans>';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          {
+            key: '{{key, number}}',
+            defaultValue: '{{key, number}}',
+            count: '{count}',
+          },
+        ]);
+      });
+
+      it('extracts keys from user-defined components', () => {
+        const content = `<div>
+      <Translate i18nKey="something">Something to translate.</Translate>
+      <NotSupported i18nKey="jkl">asdf</NotSupported>
+      <NotSupported.Translate i18nKey="jkl">asdf</NotSupported.Translate>
+      <FooBar i18nKey="asdf">Lorum Ipsum</FooBar>
+      <Namespace.A i18nKey="namespaced">Namespaced</Namespace.A>
+      <Double.Namespace.B i18nKey="namespaced2">Namespaced2</Double.Namespace.B>
+      </div>
+      `;
+        expect(
+          getKeys(
+            'test.jsx',
+            {
+              componentFunctions: [
+                'Translate',
+                'FooBar',
+                'Namespace.A',
+                'Double.Namespace.B',
+              ],
+            },
+            content
+          )
+        ).toEqual([
+          { key: 'something', defaultValue: 'Something to translate.' },
+          { key: 'asdf', defaultValue: 'Lorum Ipsum' },
+          { key: 'namespaced', defaultValue: 'Namespaced' },
+          { key: 'namespaced2', defaultValue: 'Namespaced2' },
+        ]);
+      });
+
+      it('extracts keys from single line comments', () => {
+        const content = `
+      // i18n.t('commentKey1')
+      i18n.t('commentKey' + i)
+      // i18n.t('commentKey2')
+      i18n.t(\`commentKey\${i}\`)
+      // Irrelevant comment
+      // i18n.t('commentKey3')
+      `;
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { key: 'commentKey1' },
+          { key: 'commentKey2' },
+          { key: 'commentKey3' },
+        ]);
+      });
+
+      it('extracts keys from multiline comments', () => {
+        const content = `
+      /*
+        i18n.t('commentKey1')
+        i18n.t('commentKey2')
+      */
+      i18n.t(\`commentKey\${i}\`)
+      // Irrelevant comment
+      /* i18n.t('commentKey3') */
+      `;
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { key: 'commentKey1' },
+          { key: 'commentKey2' },
+          { key: 'commentKey3' },
+        ]);
+      });
+
+      it('invalid interpolation gets stripped', () => {
+        const content =
+          '<Trans count={count}>before{{ key1, key2 }}after</Trans>';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { key: 'beforeafter', defaultValue: 'beforeafter', count: '{count}' },
+        ]);
+      });
+
+      it("doesn't add a blank key for self-closing or empty tags", () => {
+        const emptyTag = '<Trans count={count}></Trans>';
+        expect(getKeys('test.jsx', {}, emptyTag)).toEqual([]);
+
+        const selfClosing = '<Trans count={count}/>';
+        expect(getKeys('test.jsx', {}, selfClosing)).toEqual([]);
+      });
+
+      it('erases tags from content', () => {
+        const content =
+          '<Trans>a<b test={"</b>"}>c<c>z</c></b>{d}<br stuff={y}/></Trans>';
+        expect(getKeys('test.jsx', {}, content)[0].defaultValue).toEqual(
+          'a<1>c<1>z</1></1>{d}<3></3>'
+        );
+      });
+
+      it('skips dynamic children', () => {
+        const content =
+          '<Trans>My dogs are named: <ul i18nIsDynamicList>{["rupert", "max"].map(dog => (<li>{dog}</li>))}</ul></Trans>';
+        expect(getKeys('test.jsx', {}, content)[0].defaultValue).toEqual(
+          'My dogs are named: <1></1>'
+        );
+      });
+
+      it('handles spread attributes', () => {
+        const content =
+          '<Trans>My dog is named: <span {...styles}>Spot</span></Trans>';
+        expect(getKeys('test.jsx', {}, content)[0].defaultValue).toEqual(
+          'My dog is named: <1>Spot</1>'
+        );
+      });
+
+      it('erases comment expressions', () => {
+        const content = '<Trans>{/* some comment */}Some Content</Trans>';
+        expect(getKeys('test.jsx', {}, content)[0].defaultValue).toEqual(
+          'Some Content'
+        );
+      });
+
+      it('handles jsx fragments', () => {
+        const content = '<><Trans i18nKey="first" /></>';
+        expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'first' }]);
+      });
+
+      it('interpolates literal string values', () => {
+        const content = `<Trans>Some{' '}Interpolated {'Content'}</Trans>`;
+        expect(getKeys('test.jsx', {}, content)[0].defaultValue).toEqual(
+          'Some Interpolated Content'
+        );
+      });
+
+      it('uses the ns (namespace) prop', () => {
+        const content = `<Trans ns="foo">bar</Trans>`;
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { key: 'bar', defaultValue: 'bar', namespace: 'foo' },
+        ]);
+      });
+
+      it('uses the ns (namespace) prop with curly braces syntax', () => {
+        const content = `<Trans ns={'foo'}>bar</Trans>`;
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { key: 'bar', defaultValue: 'bar', namespace: 'foo' },
+        ]);
+      });
+    });
+
+    describe('supports TypeScript', () => {
+      it('supports basic tsx syntax', () => {
+        const content =
+          '<Interpolate i18nKey="first" someVar={foo() as bar} />';
+        expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'first' }]);
+      });
+
+      describe('<Interpolate>', () => {
+        it('extracts keys from i18nKey attributes', () => {
+          const content = '<Interpolate i18nKey="first" />';
+          expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'first' }]);
+        });
+      });
+
+      describe('<Trans>', () => {
+        it('extracts keys from i18nKey attributes from closing tags', () => {
+          const content = '<Trans i18nKey="first" count={count}>Yo</Trans>';
+          expect(getKeys('test.jsx', {}, content)).toEqual([
+            { key: 'first', defaultValue: 'Yo', count: '{count}' },
+          ]);
+        });
+
+        it('extracts keys from user-defined key attributes from closing tags', () => {
+          const content = '<Trans myIntlKey="first" count={count}>Yo</Trans>';
+          expect(getKeys('test.jsx', { attr: 'myIntlKey' }, content)).toEqual([
+            { key: 'first', defaultValue: 'Yo', count: '{count}' },
+          ]);
+        });
+
+        it('extracts keys from i18nKey attributes from self-closing tags', () => {
+          const content = '<Trans i18nKey="first" count={count} />';
+          expect(getKeys('test.jsx', {}, content)).toEqual([
+            { key: 'first', count: '{count}' },
+          ]);
+        });
+
+        it('does not extract variable identifier from i18nKey as key', () => {
+          const content = '<Trans i18nKey={variable} />';
+          expect(getKeys('test.jsx', {}, content)).toEqual([]);
+        });
+
+        it('extracts keys from user-defined key attributes from self-closing tags', () => {
+          const content = '<Trans myIntlKey="first" count={count} />';
+          expect(getKeys('test.jsx', { attr: 'myIntlKey' }, content)).toEqual([
+            { key: 'first', count: '{count}' },
+          ]);
+        });
+
+        it('extracts keys from Trans elements without an i18nKey', () => {
+          const content = '<Trans count={count}>Yo</Trans>';
+          expect(getKeys('test.jsx', {}, content)).toEqual([
+            { key: 'Yo', defaultValue: 'Yo', count: '{count}' },
+          ]);
+        });
+
+        it('extracts keys from Trans elements and ignores values of expressions and spaces', () => {
+          const content = '<Trans count={count}>{{ key: property }}</Trans>';
+          expect(getKeys('test.jsx', {}, content)).toEqual([
+            { key: '{{key}}', defaultValue: '{{key}}', count: '{count}' },
+          ]);
+        });
+
+        it('strips invalid interpolation', () => {
+          const content =
+            '<Trans count={count}>before{{ key1, key2 }}after</Trans>';
+          expect(getKeys('test.jsx', {}, content)).toEqual([
+            {
+              key: 'beforeafter',
+              defaultValue: 'beforeafter',
+              count: '{count}',
+            },
+          ]);
+        });
+
+        it("doesn't add a blank key for self-closing or empty tags", () => {
+          const emptyTag = '<Trans count={count}></Trans>';
+          expect(getKeys('test.jsx', {}, emptyTag)).toEqual([]);
+
+          const selfClosing = '<Trans count={count}/>';
+          expect(getKeys('test.jsx', {}, selfClosing)).toEqual([]);
+        });
+
+        it('erases tags from content', () => {
+          const content =
+            '<Trans>a<b test={"</b>"}>c<c>z</c></b>{d}<br stuff={y}/></Trans>';
+          expect(getKeys('test.jsx', {}, content)[0].defaultValue).toEqual(
+            'a<1>c<1>z</1></1>{d}<3></3>'
+          );
+        });
+
+        it('erases comment expressions', () => {
+          const content = '<Trans>{/* some comment */}Some Content</Trans>';
+          expect(getKeys('test.jsx', {}, content)[0].defaultValue).toEqual(
+            'Some Content'
+          );
+        });
+
+        it('erases typecasts', () => {
+          const content = '<Trans>{{ key: property } as any}</Trans>';
+          expect(getKeys('test.jsx', {}, content)).toEqual([
+            { key: '{{key}}', defaultValue: '{{key}}' },
+          ]);
+        });
+
+        it('keeps self-closing tags untouched when transSupportBasicHtmlNodes is true', () => {
+          const content = '<Trans>a<br />b</Trans>';
+          expect(
+            getKeys(
+              'test.jsx',
+              { transSupportBasicHtmlNodes: true },
+              content
+            )[0].defaultValue
+          ).toEqual('a<br />b');
+        });
+
+        it('keeps empty tag untouched when transSupportBasicHtmlNodes is true', () => {
+          const content = '<Trans>a<strong></strong>b</Trans>';
+          expect(
+            getKeys(
+              'test.jsx',
+              { transSupportBasicHtmlNodes: true },
+              content
+            )[0].defaultValue
+          ).toEqual('a<strong></strong>b');
+        });
+
+        it('does not unescape i18nKey', () => {
+          const content =
+            '<Trans i18nKey="I&apos;m testing">I&apos;m Testing</Trans>';
+          expect(getKeys('test.jsx', {}, content)[0].key).toEqual(
+            'I&apos;m testing'
+          );
+        });
+
+        it('unescapes key when i18nKey is not provided', () => {
+          const content = '<Trans>I&apos;m Testing</Trans>';
+          expect(getKeys('test.jsx', {}, content)[0].key).toEqual(
+            "I'm Testing"
+          );
+        });
+
+        it('supports the shouldUnescape options', () => {
+          const content = '<Trans shouldUnescape>I&apos;m Testing</Trans>';
+          const result = getKeys('test.jsx', {}, content)[0];
+          expect(result.key).toEqual("I'm Testing");
+          expect(result.defaultValue).toEqual('I&apos;m Testing');
+        });
+
+        it('supports multi-step casts', () => {
+          const content =
+            '<Trans>Hi, {{ name: "John" } as unknown as string}</Trans>';
+          expect(getKeys('test.jsx', {}, content)[0].defaultValue).toEqual(
+            'Hi, {{name}}'
+          );
+        });
+
+        it('supports variables in identity functions', () => {
+          const content = '<Trans>Hi, {funcCall({ name: "John" })}</Trans>';
+          expect(
+            getKeys(
+              'test.jsx',
+              {
+                transIdentityFunctionsToIgnore: ['funcCall'],
+              },
+              content
+            )[0].defaultValue
+          ).toEqual('Hi, {{name}}');
+        });
+      });
+    });
+  });
+
+  describe('supports JavaScript', () => {
+    it('extracts keys from translation components', () => {
+      const content = 'i18n.t("first")';
+      expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'first' }]);
+    });
+
+    it('extracts the second argument string literal as defaultValue', () => {
+      const content = 'i18n.t("first", "bla")';
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        { key: 'first', defaultValue: 'bla' },
+      ]);
+    });
+
+    it('extracts the second argument template literal as defaultValue', () => {
+      const content = 'i18n.t("first", `bla`)';
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        { key: 'first', defaultValue: 'bla' },
+      ]);
+    });
+
+    it('extracts the second argument string concatenation as defaultValue', () => {
+      const content = 'i18n.t("first", "bla" + "bla" + "bla")';
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        { key: 'first', defaultValue: 'blablabla' },
+      ]);
+    });
+
+    it('extracts the defaultValue/context options', () => {
+      const content =
+        'i18n.t("first", {defaultValue: "foo", context: \'bar\'})';
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        { key: 'first', defaultValue: 'foo', context: 'bar' },
+      ]);
+    });
+
+    it('emits a `warning` event if the option argument contains a spread operator', () => {
+      const content = `{t('foo', { defaultValue: 'bar', ...spread })}`;
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        { key: 'foo', defaultValue: 'bar' },
+      ]);
+    });
+
+    it('extracts the defaultValue/context on multiple lines', () => {
+      const content =
+        'i18n.t("first", {\ndefaultValue: "foo",\n context: \'bar\'})';
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        { key: 'first', defaultValue: 'foo', context: 'bar' },
+      ]);
+    });
+
+    it('extracts the defaultValue/context options with quotation marks', () => {
+      const content =
+        'i18n.t("first", {context: "foo", "defaultValue": \'bla\'})';
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        { key: 'first', defaultValue: 'bla', context: 'foo' },
+      ]);
+    });
+
+    it('extracts the defaultValue/context options with interpolated value', () => {
+      const content =
+        'i18n.t("first", {context: "foo", "defaultValue": \'{{var}} bla\'})';
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        { key: 'first', defaultValue: '{{var}} bla', context: 'foo' },
+      ]);
+    });
+
+    it('supports multiline and concatenation', () => {
+      const content = 'i18n.t("foo" + \n "bar")';
+      expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'foobar' }]);
+    });
+
+    it('supports multiline template literal keys', () => {
+      const content = 'i18n.t(`foo\nbar`)';
+      expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'foo\nbar' }]);
+    });
+
+    it('extracts keys from single line comments', () => {
+      const content = `
+    // i18n.t('commentKey1')
+    i18n.t('commentKey' + i)
+    // i18n.t('commentKey2')
+    i18n.t(\`commentKey\${i}\`)
+    // Irrelevant comment
+    // i18n.t('commentKey3')
+    `;
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        { key: 'commentKey1' },
+        { key: 'commentKey2' },
+        { key: 'commentKey3' },
+      ]);
+    });
+
+    it('extracts keys from multiline comments', () => {
+      const content = `
+    /*
+      i18n.t('commentKey1')
+      i18n.t('commentKey2')
+    */
+    i18n.t(\`commentKey\${i}\`)
+    // Irrelevant comment
+    /* i18n.t('commentKey3') */
+    `;
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        { key: 'commentKey1' },
+        { key: 'commentKey2' },
+        { key: 'commentKey3' },
+      ]);
+    });
+
+    it('parses namespace from `t` type argument', () => {
+      const content = `
+      const content = (t: TFunction<"foo">) => ({
+        title: t("bar"),
+      })
+    `;
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        { key: 'bar', namespace: 'foo' },
+      ]);
+    });
+
+    it("does not parse text with `doesn't` or isolated `t` in it", () => {
+      const js =
+        "// FIX this doesn't work and this t is all alone\nt('first')\nt = () => {}";
+      expect(getKeys('test.jsx', {}, js)).toEqual([{ key: 'first' }]);
+    });
+
+    it('ignores functions that ends with a t', () => {
+      const js = "ttt('first')";
+      expect(getKeys('test.jsx', {}, js)).toEqual([]);
+    });
+
+    it('supports a `functions` option', () => {
+      const content =
+        'tt("first") + _e("second") + x.tt("third") + f.g("fourth")';
+      expect(
+        getKeys('test.jsx', { functions: ['tt', '_e', 'f.g'] }, content)
+      ).toEqual([
+        { key: 'first' },
+        { key: 'second' },
+        { key: 'third' },
+        { key: 'fourth' },
+      ]);
+    });
+
+    it('supports the spread operator', () => {
+      const content =
+        'const data = { text: t("foo"), ...rest }; const { text, ...more } = data;';
+      expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'foo' }]);
+    });
+
+    it('supports the es7 syntax', () => {
+      const content = '@decorator() class Test { test() { t("foo") } }';
+      expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'foo' }]);
+    });
+
+    it('supports basic typescript syntax', () => {
+      const content = 'i18n.t("first") as potato';
+      expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'first' }]);
+    });
+    it('supports for t function in options', () => {
+      const content =
+        'i18n.t("first", {option: i18n.t("second",{option2: i18n.t("third")}), option3: i18n.t("fourth")})';
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        { key: 'first' },
+        { key: 'second' },
+        { key: 'third' },
+        { key: 'fourth' },
+      ]);
+    });
+
+    describe('useTranslation', () => {
+      it('extracts default namespace', () => {
+        const content = 'const {t} = useTranslation("foo"); t("bar");';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { namespace: 'foo', key: 'bar' },
+        ]);
+      });
+
+      it('extracts the first valid namespace when it is an array', () => {
+        const content =
+          'const {t} = useTranslation([someVariable, "baz"]); t("bar");';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { namespace: 'baz', key: 'bar' },
+        ]);
+      });
+
+      it('emits a `warning` event if the extracted namespace is not a string literal or undefined', () => {
+        const content = 'const {t} = useTranslation(someVariable); t("bar");';
+        expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'bar' }]);
+      });
+
+      it('leaves the default namespace unchanged if `undefined` is passed', () => {
+        const content = 'const {t} = useTranslation(undefined); t("bar");';
+        expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'bar' }]);
+      });
+
+      it('leaves the default namespace unchanged if `undefined` is passed in an array', () => {
+        const content =
+          'const {t} = useTranslation([someVariable, undefined]); t("bar");';
+        expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'bar' }]);
+      });
+
+      it('uses namespace from t function with priority', () => {
+        const content =
+          'const {t} = useTranslation("foo"); t("bar", {ns: "baz"});';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { namespace: 'baz', key: 'bar', ns: 'baz' },
+        ]);
+      });
+
+      it('extracts namespace with a custom hook', () => {
+        const content =
+          'const {t} = useCustomTranslationHook("foo"); t("bar");';
+        expect(
+          getKeys(
+            '',
+            { namespaceFunctions: ['useCustomTranslationHook'] },
+            content
+          )
+        ).toEqual([{ namespace: 'foo', key: 'bar' }]);
+      });
+
+      it('extracts namespace with a custom hook defined as nested properties', () => {
+        const content = 'const {t} = i18n.useTranslate("foo"); t("bar");';
+        expect(
+          getKeys(
+            'test.jsx',
+            { namespaceFunctions: ['i18n.useTranslate'] },
+            content
+          )
+        ).toEqual([{ namespace: 'foo', key: 'bar' }]);
+      });
+    });
+
+    describe('withTranslation', () => {
+      it('extracts default namespace when it is a string', () => {
+        const content =
+          'const ExtendedComponent = withTranslation("foo")(MyComponent); t("bar");';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { namespace: 'foo', key: 'bar' },
+        ]);
+      });
+
+      it('extracts first valid namespace when it is an array', () => {
+        const content =
+          'const ExtendedComponent = withTranslation([someVariable, "baz"])(MyComponent); t("bar");';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { namespace: 'baz', key: 'bar' },
+        ]);
+      });
+
+      it('emits a `warning` event if the extracted namespace is not a string literal or undefined', () => {
+        const content =
+          'const ExtendedComponent = withTranslation(someVariable)(MyComponent); t("bar");';
+        expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'bar' }]);
+      });
+
+      it('leaves the default namespace unchanged if `undefined` is passed', () => {
+        const content =
+          'const ExtendedComponent = withTranslation(undefined)(MyComponent); t("bar");';
+        expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'bar' }]);
+      });
+
+      it('leaves the default namespace unchanged if `undefined` is passed in an array', () => {
+        const content =
+          'const ExtendedComponent = withTranslation([someVariable, undefined])(MyComponent); t("bar");';
+        expect(getKeys('test.jsx', {}, content)).toEqual([{ key: 'bar' }]);
+      });
+
+      it('uses namespace from t function with priority', () => {
+        const content =
+          'const ExtendedComponent = withTranslation("foo")(MyComponent); t("bar", {ns: "baz"});';
+        expect(getKeys('test.jsx', {}, content)).toEqual([
+          { namespace: 'baz', key: 'bar', ns: 'baz' },
+        ]);
+      });
+    });
+
+    it('extracts custom options', () => {
+      const content = 'i18n.t("headline", {description: "Fantastic key!"});';
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        {
+          key: 'headline',
+          description: 'Fantastic key!',
+        },
+      ]);
+    });
+
+    it('extracts boolean options', () => {
+      const content = 'i18n.t("headline", {ordinal: true, custom: false});';
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        {
+          key: 'headline',
+          ordinal: true,
+          custom: false,
+        },
+      ]);
+    });
+
+    it('ignores dynamic keys', () => {
+      const content =
+        'const bar = "bar"; i18n.t("foo"); i18n.t(bar); i18n.t(`foo.${bar}`); i18n.t(`babar`);';
+
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        {
+          key: 'foo',
+        },
+        {
+          key: 'babar',
+        },
+      ]);
+    });
+
+    it('extracts non-interpolated tagged templates', () => {
+      const content = 'i18n.t`some-key`';
+      expect(getKeys('test.jsx', {}, content)).toEqual([
+        {
+          key: 'some-key',
+        },
+      ]);
+    });
+
+    it('skips interpolated tagged templates', () => {
+      const content = 'i18n.t`some-key${someVar}keykey`';
+      expect(getKeys('test.jsx', {}, content)).toEqual([]);
+    });
+
+    it('extracts count options', () => {
+      const content = 'i18n.t<{count: number}>("key_count");';
+      expect(
+        getKeys(
+          'file.ts',
+          { typeMap: { CountType: { count: '' } }, parseGenerics: true },
+          content
+        )
+      ).toEqual([
+        {
+          key: 'key_count',
+          count: '',
+        },
+      ]);
+
+      const content2 = `type CountType = {count : number};
+  i18n.t<CountType>("key_count");`;
+      expect(
+        getKeys(
+          'file.ts',
+          {
+            typeMap: { CountType: { count: '' } },
+            parseGenerics: true,
+          },
+          content2
+        )
+      ).toEqual([
+        {
+          count: '',
+          key: 'key_count',
+        },
+      ]);
+
+      const content3 = `type CountType = {count : number};
+     i18n.t<CountType & {my_custom: number}>("key_count");`;
+      expect(
+        getKeys(
+          'file.ts',
+          {
+            typeMap: { CountType: { count: '' } },
+            parseGenerics: true,
+          },
+          content3
+        )
+      ).toEqual([
+        {
+          key: 'key_count',
+          count: '',
+          my_custom: '',
+        },
+      ]);
+
+      const content4 = `type CountType = {count : number};
+     i18n.t<CountType | {my_custom: number}>("key_count");`;
+      expect(
+        getKeys(
+          'file.ts',
+          {
+            typeMap: { CountType: { count: '' } },
+            parseGenerics: true,
+          },
+          content4
+        )
+      ).toEqual([
+        {
+          key: 'key_count',
+          count: '',
+          my_custom: '',
+        },
+      ]);
+    });
+  });
+});

--- a/src/utils/i18NextSrcParser.ts
+++ b/src/utils/i18NextSrcParser.ts
@@ -1,0 +1,954 @@
+/**
+ *
+ * Based on the original [i18next-parser](https://github.com/i18next/i18next-parser)
+ *
+ */
+
+import * as ts from 'typescript';
+
+const USE_TRANSLATION = 'useTranslation';
+const WITH_TRANSLATION = 'withTranslation';
+const TRANSLATION_TYPE = 'TFunction';
+
+type Options = {
+  attr: string;
+  componentFunctions: string[];
+  functions: string[];
+  namespaceFunctions: string[];
+  parseGenerics: boolean;
+  transSupportBasicHtmlNodes: boolean;
+  transIdentityFunctionsToIgnore: string[];
+  typeMap: Record<string, unknown>;
+  translationFunctionsWithArgs: Record<
+    string,
+    {
+      pos: number;
+      storeGlobally: boolean;
+      keyPrefix?: string;
+      ns?: string;
+    }
+  >;
+  keyPrefix?: string;
+  defaultNamespace?: string;
+  transKeepBasicHtmlNodesFor: string[];
+  omitAttributes: string[];
+};
+
+type FoundKey = {
+  key: string;
+  ns?: string;
+  namespace?: string;
+  functionName?: string;
+  defaultValue?: string;
+  [key: string]: unknown;
+};
+
+export const getKeys = (
+  path: string,
+  options: Partial<Options>,
+  content: string
+) => {
+  const sourceFile = ts.createSourceFile(
+    path,
+    content,
+    ts.ScriptTarget.Latest,
+    true
+  );
+
+  const defaultOptions: Options = {
+    attr: 'i18nKey',
+    componentFunctions: ['Trans'],
+    functions: ['t'],
+    namespaceFunctions: [USE_TRANSLATION, WITH_TRANSLATION],
+    parseGenerics: false,
+    transSupportBasicHtmlNodes: false,
+    transIdentityFunctionsToIgnore: [],
+    typeMap: {},
+    translationFunctionsWithArgs: {},
+    transKeepBasicHtmlNodesFor: ['br', 'strong', 'i', 'p'],
+    omitAttributes: ['ns', 'defaults'],
+  };
+
+  const parserOptions = { ...defaultOptions, ...options };
+  parserOptions.omitAttributes = [
+    parserOptions.attr,
+    ...parserOptions.omitAttributes,
+  ];
+
+  let foundKeys: FoundKey[] = [];
+
+  const visit = (node: ts.Node) => {
+    if (ts.isVariableDeclaration(node)) {
+      extractFromVariableDeclaration(node, parserOptions);
+    }
+
+    if (ts.isCallExpression(node)) {
+      const keys = extractFromExpression(node, parserOptions);
+      if (keys) {
+        foundKeys = foundKeys.concat(keys);
+      }
+    }
+
+    if (ts.isTaggedTemplateExpression(node)) {
+      const key = extractFromTaggedTemplateExpression(node, parserOptions);
+      if (key) {
+        foundKeys.push(key);
+      }
+    }
+
+    if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) {
+      const key = extractFromJsx(node, content, parserOptions);
+      if (key) {
+        foundKeys.push(key);
+      }
+    }
+
+    if (ts.isArrowFunction(node) || ts.isFunctionDeclaration(node)) {
+      extractFromFunction(node, parserOptions);
+    }
+
+    // Collect all keys defined in comments
+    const commentKeys: FoundKey[] = [];
+    ts.forEachLeadingCommentRange(
+      content,
+      node.getFullStart(),
+      (pos, end, kind) => {
+        if (
+          kind === ts.SyntaxKind.MultiLineCommentTrivia ||
+          kind === ts.SyntaxKind.SingleLineCommentTrivia
+        ) {
+          const text = content.slice(pos, end);
+          const functionPattern =
+            '(?:' + parserOptions.functions.join('|').replace('.', '\\.') + ')';
+
+          const callPattern = '(?<=^|\\s|\\.)' + functionPattern + '\\(.*\\)';
+          const regexp = new RegExp(callPattern, 'g');
+          const expressions = text.match(regexp);
+
+          if (!expressions) {
+            return null;
+          }
+
+          const foundKeys: FoundKey[] = [];
+          expressions.forEach((expression) => {
+            const expressionKeys = getKeys('', {}, expression);
+            if (expressionKeys) {
+              commentKeys.push(...expressionKeys);
+            }
+          });
+          if (foundKeys) {
+            commentKeys.push(...foundKeys);
+          }
+        }
+      }
+    );
+    if (commentKeys) {
+      commentKeys.forEach((key) => {
+        if (!foundKeys.find((k) => k.key === key.key)) {
+          foundKeys.push(key);
+        }
+      });
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  ts.forEachChild(sourceFile, visit);
+
+  return foundKeys;
+};
+
+// Taken from: https://github.com/i18next/i18next-parser/blob/6c10a2b66ebadb8250039d078ad2a53e52753a6e/src/lexers/jsx-lexer.js#L74
+const extractFromJsx = (
+  node: ts.JsxElement | ts.JsxSelfClosingElement,
+  content: string,
+  options: Options
+) => {
+  const tagNode = ts.isJsxElement(node) ? node.openingElement : node;
+
+  const getKey = (node: ts.JsxSelfClosingElement | ts.JsxOpeningElement) =>
+    getPropertyValue(node, options.attr);
+
+  if (options.componentFunctions.includes(expressionToName(tagNode.tagName))) {
+    const entry: FoundKey = { key: getKey(tagNode) ?? '' };
+
+    const namespace = getPropertyValue(tagNode, 'ns');
+    if (namespace) {
+      entry.namespace = namespace;
+    }
+
+    tagNode.attributes.properties.forEach((property) => {
+      if (property.kind === ts.SyntaxKind.JsxSpreadAttribute) {
+        return;
+      }
+
+      const propertyName = property.name.getText();
+
+      if (options.omitAttributes.includes(propertyName)) {
+        return;
+      }
+
+      if (property.initializer) {
+        if (
+          ts.isJsxExpression(property.initializer) &&
+          property.initializer.expression
+        ) {
+          if (
+            property.initializer.expression.kind === ts.SyntaxKind.TrueKeyword
+          ) {
+            entry[propertyName] = true;
+          } else if (
+            property.initializer.expression.kind === ts.SyntaxKind.FalseKeyword
+          ) {
+            entry[propertyName] = false;
+          } else {
+            entry[propertyName] = `{${cleanMultiLineCode(
+              content.slice(
+                property.initializer.expression.pos,
+                property.initializer.expression.end
+              )
+            )}}`;
+          }
+        } else if (ts.isStringLiteral(property.initializer)) {
+          entry[propertyName] = property.initializer.text;
+        }
+      } else {
+        entry[propertyName] = true;
+      }
+    });
+
+    const nodeAsString = nodeToString(node, content, options);
+    const defaultsProp = getPropertyValue(tagNode, 'defaults');
+    let defaultValue = defaultsProp || nodeAsString;
+
+    if (entry.shouldUnescape !== true) {
+      defaultValue = unescape(defaultValue);
+    }
+    if (defaultValue !== '') {
+      entry.defaultValue = defaultValue;
+
+      if (!entry.key) {
+        entry.key = unescape(nodeAsString) || entry.defaultValue || '';
+      }
+    }
+
+    return entry.key ? entry : null;
+  } else if (tagNode.tagName.getText() === 'Interpolate') {
+    const entry: FoundKey = { key: getKey(tagNode) ?? '' };
+    return entry.key ? entry : null;
+  } else if (tagNode.tagName.getText() === 'Translation') {
+    const namespace = getPropertyValue(tagNode, 'ns');
+    if (namespace) {
+      options.defaultNamespace = namespace;
+    }
+  }
+};
+
+// Taken from: https://github.com/i18next/i18next-parser/blob/6c10a2b66ebadb8250039d078ad2a53e52753a6e/src/lexers/jsx-lexer.js#L77
+const getPropertyValue = (
+  node: ts.JsxSelfClosingElement | ts.JsxOpeningElement,
+  attr: string
+) => {
+  const attribute = node.attributes.properties.find(
+    (attribute: ts.JsxAttributeLike) => {
+      return attribute.name !== undefined && attribute.name.getText() === attr;
+    }
+  );
+
+  if (!attribute) {
+    return undefined;
+  }
+
+  if (
+    !ts.isJsxAttribute(attribute) ||
+    !attribute.initializer ||
+    (ts.isJsxExpression(attribute.initializer) &&
+      attribute.initializer?.expression &&
+      ts.isIdentifier(attribute.initializer?.expression))
+  ) {
+    return undefined;
+  }
+
+  if (ts.isStringLiteral(attribute.initializer)) {
+    return attribute.initializer.text;
+  }
+
+  if (
+    ts.isJsxExpression(attribute.initializer) &&
+    attribute.initializer?.expression &&
+    (ts.isStringLiteral(attribute.initializer?.expression) ||
+      ts.isNoSubstitutionTemplateLiteral(attribute.initializer.expression))
+  ) {
+    return attribute.initializer.expression.text;
+  }
+
+  return undefined;
+};
+
+// Taken from: https://github.com/i18next/i18next-parser/blob/6c10a2b66ebadb8250039d078ad2a53e52753a6e/src/lexers/javascript-lexer.js#L165
+const extractFromTaggedTemplateExpression = (
+  node: ts.TaggedTemplateExpression,
+  options: Options
+): FoundKey | undefined => {
+  const { tag, template } = node;
+
+  if (
+    !options.functions.includes(tag.getText()) &&
+    !(
+      ts.isPropertyAccessExpression(tag) &&
+      options.functions.includes(tag.name.text)
+    )
+  ) {
+    return undefined;
+  }
+
+  if (ts.isNoSubstitutionTemplateLiteral(template)) {
+    return { key: template.text };
+  }
+
+  return undefined;
+};
+
+// Taken from: https://github.com/i18next/i18next-parser/blob/6c10a2b66ebadb8250039d078ad2a53e52753a6e/src/lexers/javascript-lexer.js#L75
+const extractFromVariableDeclaration = (
+  node: ts.VariableDeclaration,
+  options: Options
+) => {
+  if (ts.isIdentifier(node.name)) {
+    return undefined;
+  }
+  const [firstElement] = node.name.elements;
+
+  if (!ts.isBindingElement(firstElement)) {
+    return undefined;
+  }
+  const firstElementName = firstElement?.propertyName ?? firstElement.name;
+
+  if (
+    hasEscapedText(firstElementName) &&
+    firstElementName?.escapedText === 't' &&
+    hasEscapedText(firstElement.name) &&
+    options.functions.includes(firstElement?.name?.escapedText.toString()) &&
+    node.initializer &&
+    ts.isCallExpression(node.initializer) &&
+    ts.isIdentifier(node.initializer.expression) &&
+    options.namespaceFunctions.includes(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      node.initializer?.expression?.escapedText
+    )
+  ) {
+    options.translationFunctionsWithArgs[
+      firstElement.name.escapedText.toString()
+    ] = {
+      pos: node.initializer.pos,
+      storeGlobally: !(
+        firstElement.propertyName &&
+        hasEscapedText(firstElement.propertyName) &&
+        firstElement.propertyName?.escapedText
+      ),
+    };
+  }
+};
+
+// Taken from: https://github.com/i18next/i18next-parser/blob/6c10a2b66ebadb8250039d078ad2a53e52753a6e/src/lexers/javascript-lexer.js#L138
+const extractFromFunction = (
+  node: ts.FunctionLikeDeclaration,
+  options: Options
+) => {
+  const tFnParam =
+    node.parameters &&
+    node.parameters.find(
+      (param) =>
+        param.name &&
+        ts.isIdentifier(param.name) &&
+        options.functions.includes(param.name.text)
+    );
+
+  if (
+    tFnParam &&
+    tFnParam.type &&
+    ts.isTypeReferenceNode(tFnParam.type) &&
+    tFnParam.type.typeName &&
+    ts.isIdentifier(tFnParam.type.typeName) &&
+    tFnParam.type.typeName.text === TRANSLATION_TYPE
+  ) {
+    if (tFnParam.type.typeArguments && tFnParam.type.typeArguments.length > 0) {
+      const [firstArgument] = tFnParam.type.typeArguments;
+
+      if (
+        ts.isLiteralTypeNode(firstArgument) &&
+        ts.isStringLiteral(firstArgument.literal)
+      ) {
+        options.defaultNamespace = firstArgument.literal.text;
+      }
+    }
+  }
+};
+
+// Taken from: https://github.com/i18next/i18next-parser/blob/6c10a2b66ebadb8250039d078ad2a53e52753a6e/src/lexers/javascript-lexer.js#L189
+const extractFromExpression = (node: ts.CallExpression, options: Options) => {
+  const entries: FoundKey[] = [{ key: '' }];
+
+  const functionDefinition = Object.entries(
+    options.translationFunctionsWithArgs
+  ).find(([_name, translationFunc]) => translationFunc?.pos === node.pos);
+  let storeGlobally = functionDefinition?.[1].storeGlobally ?? true;
+
+  const isNamespaceFunction =
+    (ts.isIdentifier(node.expression) &&
+      node.expression.escapedText &&
+      options.namespaceFunctions.includes(node.expression.escapedText)) ||
+    options.namespaceFunctions.includes(expressionToName(node.expression));
+
+  if (isNamespaceFunction && node.arguments.length > 0) {
+    storeGlobally =
+      storeGlobally ||
+      (hasEscapedText(node.expression) &&
+        node.expression.escapedText === WITH_TRANSLATION);
+    const [namespaceArgument, optionsArgument] = node.arguments;
+
+    const namespaces = ts.isArrayLiteralExpression(namespaceArgument)
+      ? namespaceArgument.elements
+      : [namespaceArgument];
+
+    const namespace = namespaces.find(
+      (namespace) =>
+        ts.isStringLiteral(namespace) ||
+        (ts.isIdentifier(namespace) && namespace.text === 'undefined')
+    );
+
+    if (!namespace) {
+      // No namespace found - technically a warning could be logged here
+    } else if (ts.isStringLiteral(namespace)) {
+      if (storeGlobally) {
+        options.defaultNamespace = namespace.text;
+      }
+      entries[0].ns = namespace.text;
+    }
+
+    if (optionsArgument && ts.isObjectLiteralExpression(optionsArgument)) {
+      const keyPrefixNode = optionsArgument.properties.find(
+        (p) =>
+          p.name &&
+          hasEscapedText(p.name) &&
+          p.name?.escapedText === 'keyPrefix'
+      );
+      if (keyPrefixNode != null && ts.isPropertyAssignment(keyPrefixNode)) {
+        if (storeGlobally) {
+          options.keyPrefix = keyPrefixNode.initializer.getText();
+        }
+        entries[0].keyPrefix = keyPrefixNode.initializer.getText();
+      }
+    }
+  }
+
+  const isTranslationFunction =
+    (ts.isStringLiteral(node.expression) &&
+      node.expression.text &&
+      options.functions.includes(node.expression.text)) ||
+    (hasName(node.expression) &&
+      node.expression.name &&
+      hasText(node.expression.name) &&
+      options.functions.includes(node.expression.name.text)) ||
+    options.functions.includes(expressionToName(node.expression));
+
+  if (isTranslationFunction) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const keyArgument = node.arguments.shift();
+
+    if (!keyArgument) {
+      return null;
+    }
+
+    if (
+      ts.isStringLiteral(keyArgument) ||
+      ts.isNoSubstitutionTemplateLiteral(keyArgument)
+    ) {
+      entries[0].key = keyArgument.text;
+    } else if (ts.isBinaryExpression(keyArgument)) {
+      const concatenatedString = concatenateString(keyArgument);
+      if (!concatenatedString) {
+        return null;
+      }
+      entries[0].key = concatenatedString;
+    } else {
+      return null;
+    }
+
+    if (options.parseGenerics && node.typeArguments) {
+      const nodeTypeArguments = copyNodeArray(node.typeArguments);
+      const typeArgument = nodeTypeArguments.shift();
+
+      const parseTypeArgument = (typeNode: ts.TypeNode | undefined) => {
+        if (!typeNode) {
+          return;
+        }
+        if (ts.isTypeLiteralNode(typeNode)) {
+          for (const member of typeNode.members) {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            entries[0][member.name?.text] = '';
+          }
+        } else if (
+          ts.isTypeReferenceNode(typeNode) &&
+          ts.isIdentifier(typeNode.typeName)
+        ) {
+          const typeName = typeNode.typeName.text;
+          if (typeName in options.typeMap) {
+            Object.assign(entries[0], options.typeMap[typeName]);
+          }
+        } else if (
+          (ts.isUnionTypeNode(typeNode) ||
+            ts.isIntersectionTypeNode(typeNode)) &&
+          Array.isArray(typeNode.types)
+        ) {
+          typeNode.types.forEach((type) => parseTypeArgument(type));
+        }
+      };
+
+      parseTypeArgument(typeArgument);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    let optionsArgument = node.arguments.shift();
+
+    if (
+      optionsArgument &&
+      (ts.isStringLiteral(optionsArgument) ||
+        ts.isNoSubstitutionTemplateLiteral(optionsArgument))
+    ) {
+      entries[0].defaultValue = optionsArgument.text;
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      optionsArgument = node.arguments.shift();
+    } else if (optionsArgument && ts.isBinaryExpression(optionsArgument)) {
+      const concatenatedString = concatenateString(optionsArgument);
+      if (!concatenatedString) {
+        return null;
+      }
+      entries[0].defaultValue = concatenatedString;
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      optionsArgument = node.arguments.shift();
+    }
+
+    if (optionsArgument && ts.isObjectLiteralExpression(optionsArgument)) {
+      for (const optionProperty of optionsArgument.properties) {
+        if (ts.isSpreadAssignment(optionProperty)) {
+          // Skip as this can't be processed. A warning could be logged at some point.
+        } else if (ts.isPropertyAssignment(optionProperty)) {
+          const propertyName = getNodeText(optionProperty.name);
+          if (optionProperty.initializer.kind === ts.SyntaxKind.TrueKeyword) {
+            entries[0][propertyName] = true;
+          } else if (
+            optionProperty.initializer.kind === ts.SyntaxKind.FalseKeyword
+          ) {
+            entries[0][propertyName] = false;
+          } else if (ts.isCallExpression(optionProperty.initializer)) {
+            const nestedEntries = extractFromExpression(
+              optionProperty.initializer,
+              options
+            );
+            if (nestedEntries) {
+              entries.push(...nestedEntries);
+            } else {
+              entries[0][propertyName] =
+                getNodeText(optionProperty.initializer) || '';
+            }
+          } else {
+            entries[0][propertyName] =
+              getNodeText(optionProperty.initializer) || '';
+          }
+        } else {
+          entries[0][getNodeText(optionProperty.name)] = '';
+        }
+      }
+    }
+
+    if (entries[0].ns) {
+      if (typeof entries[0].ns === 'string') {
+        entries[0].namespace = entries[0].ns;
+        // Need to double check if this is even needed
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+      } else if (Array.isArray(entries[0].ns) && entries[0].ns.length) {
+        entries[0].namespace = entries[0].ns[0];
+      }
+    }
+    entries[0].functionName = hasEscapedText(node.expression)
+      ? node.expression.escapedText.toString()
+      : node.expression.getText();
+
+    return entries
+      .map((entry) => {
+        const namespace =
+          entry.ns ??
+          options.translationFunctionsWithArgs?.[entry.functionName ?? '']
+            ?.ns ??
+          options.defaultNamespace;
+        return namespace
+          ? {
+              ...entry,
+              namespace,
+            }
+          : entry;
+      })
+      .map(({ functionName, ...key }) => {
+        const keyPrefix =
+          options.translationFunctionsWithArgs?.[functionName ?? '']
+            ?.keyPrefix ?? options.keyPrefix;
+        return keyPrefix
+          ? {
+              ...key,
+              keyPrefix,
+            }
+          : key;
+      });
+  }
+
+  const isTranslationFunctionCreation =
+    hasEscapedText(node.expression) &&
+    node.expression.escapedText &&
+    options.namespaceFunctions.includes(node.expression.escapedText);
+  if (isTranslationFunctionCreation) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    options.translationFunctionsWithArgs[functionDefinition?.[0] ?? ''] =
+      entries[0];
+  }
+  return null;
+};
+
+// Taken from: https://github.com/i18next/i18next-parser/blob/6c10a2b66ebadb8250039d078ad2a53e52753a6e/src/lexers/javascript-lexer.js#L419
+const concatenateString = (
+  binaryExpression: ts.BinaryExpression,
+  string = ''
+) => {
+  if (!ts.isPlusToken(binaryExpression.operatorToken)) {
+    return;
+  }
+
+  if (ts.isBinaryExpression(binaryExpression.left)) {
+    string += concatenateString(binaryExpression.left, string);
+  } else if (ts.isStringLiteral(binaryExpression.left)) {
+    string += binaryExpression.left.text;
+  } else {
+    return;
+  }
+
+  if (ts.isBinaryExpression(binaryExpression.right)) {
+    string += concatenateString(binaryExpression.right, string);
+  } else if (ts.isStringLiteral(binaryExpression.right)) {
+    string += binaryExpression.right.text;
+  } else {
+    return;
+  }
+
+  return string;
+};
+
+// Taken from: https://github.com/i18next/i18next-parser/blob/6c10a2b66ebadb8250039d078ad2a53e52753a6e/src/lexers/jsx-lexer.js#L186
+const nodeToString = (
+  node: ts.JsxElement | ts.JsxFragment | ts.JsxSelfClosingElement,
+  content: string,
+  options: Options
+) => {
+  if (ts.isJsxSelfClosingElement(node)) {
+    return '';
+  }
+  const elements = parseElements(node.children, content, options);
+
+  const elementsToString = (elements: ParsedJsxElements[]): string =>
+    elements
+      .map((element, index) => {
+        switch (element.type) {
+          case 'js':
+          case 'text':
+            return element.content;
+          case 'tag': {
+            const useTagName =
+              element.isBasic &&
+              options.transSupportBasicHtmlNodes &&
+              options.transKeepBasicHtmlNodesFor.includes(element.name);
+            const elementName = useTagName ? element.name : index;
+            const childrenString = elementsToString(element.children);
+            return childrenString || !(useTagName && element.selfClosing)
+              ? `<${elementName}>${childrenString}</${elementName}>`
+              : `<${elementName} />`;
+          }
+
+          default:
+          // Do nothing
+        }
+      })
+      .join('');
+
+  return elementsToString(elements);
+};
+
+type ParsedJsxElements =
+  | {
+      type: 'text';
+      content: string;
+    }
+  | {
+      type: 'js';
+      content: string;
+    }
+  | {
+      type: 'tag';
+      name: string;
+      isBasic: boolean;
+      selfClosing: boolean;
+      children: ParsedJsxElements[];
+    };
+
+// Taken from: https://github.com/i18next/i18next-parser/blob/6c10a2b66ebadb8250039d078ad2a53e52753a6e/src/lexers/jsx-lexer.js#L226
+const parseElements = (
+  elements: ts.NodeArray<ts.JsxChild>,
+  content: string,
+  options: Options
+): ParsedJsxElements[] => {
+  if (!elements) {
+    return [];
+  }
+  return elements
+    .map(
+      (
+        elem:
+          | ts.JsxChild
+          | ts.AsExpression
+          | (ts.Node & { expression: ts.Expression })
+      ) => {
+        if (ts.isJsxText(elem)) {
+          return {
+            type: 'text',
+            content: cleanMultiLineCode(elem.text),
+          } as const;
+        } else if (ts.isJsxElement(elem) || ts.isJsxSelfClosingElement(elem)) {
+          const element = ts.isJsxElement(elem) ? elem.openingElement : elem;
+          const name = hasEscapedText(element.tagName)
+            ? element.tagName.escapedText.toString()
+            : element.tagName.getText();
+          const isBasic = !element.attributes.properties.length;
+          const hasDynamicChildren = element.attributes.properties.find(
+            (prop) =>
+              ts.isJsxAttribute(prop) &&
+              hasEscapedText(prop.name) &&
+              prop.name.escapedText === 'i18nIsDynamicList'
+          );
+          return {
+            type: 'tag',
+            children:
+              hasDynamicChildren || !ts.isJsxElement(elem)
+                ? []
+                : parseElements(elem.children, content, options),
+            name,
+            isBasic,
+            selfClosing: ts.isJsxSelfClosingElement(elem),
+          } as const;
+        } else if (ts.isJsxExpression(elem)) {
+          if (!elem.expression) {
+            return {
+              type: 'text',
+              content: '',
+            } as const;
+          }
+
+          //Taken from: https://github.com/i18next/i18next-parser/blob/6c10a2b66ebadb8250039d078ad2a53e52753a6e/src/lexers/jsx-lexer.js#L265
+          while (
+            hasExpression(elem) &&
+            elem.expression &&
+            ts.isAsExpression(elem.expression)
+          ) {
+            elem = elem.expression;
+          }
+
+          if (
+            hasExpression(elem) &&
+            ts.isCallExpression(elem.expression) &&
+            ts.isIdentifier(elem.expression.expression) &&
+            options.transIdentityFunctionsToIgnore.includes(
+              elem.expression.expression.escapedText.toString()
+            ) &&
+            elem.expression.arguments.length >= 1
+          ) {
+            // Taken from: https://github.com/i18next/i18next-parser/blob/6c10a2b66ebadb8250039d078ad2a53e52753a6e/src/lexers/jsx-lexer.js#L291
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            elem = { expression: elem.expression.arguments[0] };
+          }
+
+          if (hasExpression(elem) && ts.isStringLiteral(elem.expression)) {
+            return {
+              type: 'text',
+              content: elem.expression.text,
+            } as const;
+          } else if (
+            hasExpression(elem) &&
+            ts.isObjectLiteralExpression(elem.expression)
+          ) {
+            const nonFormatProperties = elem.expression.properties.filter(
+              (prop) => prop.name?.getText() !== 'format'
+            );
+            const formatProperty = elem.expression.properties.find(
+              (prop) => prop.name?.getText() === 'format'
+            );
+
+            if (nonFormatProperties.length > 1) {
+              return {
+                type: 'text',
+                content: '',
+              } as const;
+            }
+
+            const nonFormatPropertyName = nonFormatProperties[0]?.name
+              ? getNodeText(nonFormatProperties[0].name)
+              : '';
+
+            const value =
+              formatProperty && ts.isPropertyAssignment(formatProperty)
+                ? `${nonFormatPropertyName}, ${getNodeText(formatProperty.initializer)}`
+                : nonFormatPropertyName;
+
+            return {
+              type: 'js',
+              content: `{{${value}}}`,
+            } as const;
+          }
+
+          if (hasExpression(elem)) {
+            const slicedExpression = content.slice(
+              elem.expression.pos,
+              elem.expression.end
+            );
+
+            return {
+              type: 'js',
+              content: `{${slicedExpression}}`,
+            } as const;
+          }
+        }
+      }
+    )
+    .filter((elem) => elem !== undefined)
+    .filter((elem) => elem.type !== 'text' || elem.content);
+};
+
+// Taken from: https://github.com/i18next/i18next-parser/blob/6c10a2b66ebadb8250039d078ad2a53e52753a6e/src/lexers/jsx-lexer.js#L220
+const cleanMultiLineCode = (text: string) => {
+  return text
+    .replace(/(^(\n|\r)\s*)|((\n|\r)\s*$)/g, '')
+    .replace(/(\n|\r)\s*/g, ' ');
+};
+
+// Taken from: https://github.com/i18next/i18next-parser/blob/6c10a2b66ebadb8250039d078ad2a53e52753a6e/src/lexers/javascript-lexer.js#L447
+const expressionToName = (
+  expression: ts.Expression | ts.JsxTagNameExpression
+): string => {
+  if (!expression) {
+    return '';
+  }
+
+  if (ts.isStringLiteral(expression) || ts.isIdentifier(expression)) {
+    return expression.text;
+  } else if (hasExpression(expression)) {
+    return [
+      expressionToName(expression.expression),
+      expressionToName(expression.name),
+    ]
+      .filter((s) => s && s.length > 0)
+      .join('.');
+  }
+
+  return '';
+};
+
+const hasExpression = (
+  node: ts.Node
+): node is ts.Node & { expression: ts.Expression } => {
+  return (
+    'expression' in node &&
+    !!node.expression &&
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ts.isExpression((node as any).expression)
+  );
+};
+
+const hasEscapedText = (node: ts.Node) => {
+  return ts.isIdentifier(node) || ts.isPrivateIdentifier(node);
+};
+
+const hasName = (node: ts.Node): node is ts.NamedDeclaration => {
+  return 'name' in node && node.name !== undefined;
+};
+
+function hasText(
+  node: ts.Node
+): node is
+  | ts.StringLiteral
+  | ts.NumericLiteral
+  | ts.BigIntLiteral
+  | ts.NoSubstitutionTemplateLiteral
+  | ts.RegularExpressionLiteral
+  | ts.Identifier {
+  const result =
+    node &&
+    (ts.isStringLiteral(node) ||
+      ts.isNumericLiteral(node) ||
+      ts.isBigIntLiteral(node) ||
+      ts.isNoSubstitutionTemplateLiteral(node) ||
+      ts.isRegularExpressionLiteral(node) ||
+      ts.isIdentifier(node));
+
+  return result;
+}
+
+const getNodeText = (node: ts.Node): string => {
+  if ('text' in node) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (node as any).text;
+  }
+  return node.getText();
+};
+
+const copyNodeArray = <T extends ts.Node>(nodes: ts.NodeArray<T>): T[] => {
+  return Array.from(nodes);
+};
+
+// Uses the original unescape code from i18next-parser
+// to ensure that the found keys reflect the original parser implementation
+// Taken from: https://github.com/i18next/i18next-parser/blob/6c10a2b66ebadb8250039d078ad2a53e52753a6e/src/helpers.js#L317
+const unescape = (text: string) => {
+  const matchHtmlEntity =
+    /&(?:amp|#38|lt|#60|gt|#62|apos|#39|quot|#34|nbsp|#160|copy|#169|reg|#174|hellip|#8230|#x2F|#47);/g;
+  const htmlEntities: Record<string, string> = {
+    '&amp;': '&',
+    '&#38;': '&',
+    '&lt;': '<',
+    '&#60;': '<',
+    '&gt;': '>',
+    '&#62;': '>',
+    '&apos;': "'",
+    '&#39;': "'",
+    '&quot;': '"',
+    '&#34;': '"',
+    '&nbsp;': ' ',
+    '&#160;': ' ',
+    '&copy;': '©',
+    '&#169;': '©',
+    '&reg;': '®',
+    '&#174;': '®',
+    '&hellip;': '…',
+    '&#8230;': '…',
+    '&#x2F;': '/',
+    '&#47;': '/',
+  };
+
+  const unescapeHtmlEntity = (m: string) => htmlEntities[m];
+
+  return text.replace(matchHtmlEntity, unescapeHtmlEntity);
+};


### PR DESCRIPTION
Removes deprecated `i18next-parser` and adds `i18NextScrParser` to keep the existing functionality.
https://github.com/lingualdev/i18n-check/issues/98