### PR TITLE
Enable i18next context option to be processed

### DIFF
--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -707,7 +707,9 @@ ${formatTable([
       const result = await execAsyncWithExitCode(cmd);
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain('Only one locale file found. Skipping missingKeys and invalidKeys checks.');
+      expect(result.stdout).toContain(
+        'Only one locale file found. Skipping missingKeys and invalidKeys checks.'
+      );
     });
 
     it('should handle single locale file gracefully without failing', async () => {
@@ -718,7 +720,9 @@ ${formatTable([
       const result = stdout.split('Done')[0];
       expect(result).toContain('i18n translations checker');
       expect(result).toContain('Source: en-US');
-      expect(result).toContain('Only one locale file found. Skipping missingKeys and invalidKeys checks.');
+      expect(result).toContain(
+        'Only one locale file found. Skipping missingKeys and invalidKeys checks.'
+      );
       expect(result).not.toContain('Found missing keys!');
       expect(result).not.toContain('Found invalid keys!');
     });
@@ -745,7 +749,9 @@ Only one locale file found. Skipping missingKeys and invalidKeys checks.
       const result = await execAsyncWithExitCode(cmd);
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain('Only one locale file found. Skipping missingKeys and invalidKeys checks.');
+      expect(result.stdout).toContain(
+        'Only one locale file found. Skipping missingKeys and invalidKeys checks.'
+      );
     });
   });
 
@@ -1057,7 +1063,9 @@ Only one locale file found. Skipping missingKeys and invalidKeys checks.
       const result = await execAsyncWithExitCode(cmd);
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain('Only one locale file found. Skipping missingKeys and invalidKeys checks.');
+      expect(result.stdout).toContain(
+        'Only one locale file found. Skipping missingKeys and invalidKeys checks.'
+      );
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ import { I18NEXT_PLURAL_SUFFIX } from './utils/constants';
 
 const ParseFormats = ['react-intl', 'i18next', 'next-intl'];
 
+const CONTEXT_SEPARATOR = '_';
+
 export const checkInvalidTranslations = (
   source: Translation,
   targets: Record<string, Translation>,
@@ -340,7 +342,7 @@ const findUndefinedI18NextKeys = async (
       .flatMap(({ content }) => {
         return Object.keys(content);
       })
-      // Ensure that any plural definitiions like key_one, key_other etc.
+      // Ensure that any plural definitions like key_one, key_other etc.
       // are flatted into a single key
       .map((key) => {
         const pluralSuffix = I18NEXT_PLURAL_SUFFIX.find((suffix) => {
@@ -456,7 +458,9 @@ const getI18NextKeysInCode = async (
       } else {
         extractedResult.push({
           file,
-          key: entry.key,
+          key: entry.context
+            ? `${entry.key}${CONTEXT_SEPARATOR}${entry.context}`
+            : entry.key,
           namespace: entry.namespace,
         });
       }

--- a/translations/codeExamples/reacti18next/locales/en/translation.json
+++ b/translations/codeExamples/reacti18next/locales/en/translation.json
@@ -52,5 +52,10 @@
   },
   "countedEntries": "{{count}} entries",
   "countedEntriesTwo_one": "{{count}} entry",
-  "countedEntriesTwo_other": "{{count}} entries"
+  "countedEntriesTwo_other": "{{count}} entries",
+  "context": "context",
+  "context_a": "context a",
+  "context_b": "context_b",
+  "context_c_one": "context_c_one",
+  "context_c_other": "context_c_other"
 }

--- a/translations/codeExamples/reacti18next/locales/fr/translation.json
+++ b/translations/codeExamples/reacti18next/locales/fr/translation.json
@@ -52,5 +52,10 @@
   },
   "countedEntries_one": "{{count}} entry",
   "countedEntries_other": "{{count}} entries",
-  "countedEntriesTwo": "{{count}} entry"
+  "countedEntriesTwo": "{{count}} entry",
+  "context": "context",
+  "context_a": "context a",
+  "context_b": "context_b",
+  "context_c_one": "context_c_one",
+  "context_c_other": "context_c_other"
 }

--- a/translations/codeExamples/reacti18next/src/App.tsx
+++ b/translations/codeExamples/reacti18next/src/App.tsx
@@ -16,6 +16,12 @@ export const I18NextExample = () => {
 
   const resolution = returnObjectLike['one'];
 
+  const contextKey0 = t('context');
+  const contextKey1 = t('context', { context: 'a' });
+  const contextKey2 = t('context', { context: 'b' });
+  const contextKey3 = t('context', { context: 'c', count: 1 });
+  const contextKey4 = t('context', { context: 'c', count: 100 });
+
   // Define static keys for any dynamically defined keys for the parser to identify them
   // https://github.com/i18next/i18next-parser?tab=readme-ov-file#caveats
   // t('some.deep.nested.otherKey')


### PR DESCRIPTION
Ensure that the context option is processed correctly to ensure that the generated key matches the locales key.

```ts
 const contextKey0 = t('context');
 const contextKey1 = t('context', { context: 'a' });
 const contextKey2 = t('context', { context: 'b' });
 const contextKey3 = t('context', { context: 'c', count: 1 });
 const contextKey4 = t('context', { context: 'c', count: 100 });
```

```json
"context": "context",
"context_a": "context a",
"context_b": "context_b",
"context_c_one": "context_c_one",
"context_c_other": "context_c_other"
```

#114 