### PR TITLE
Enable i18next selector api keys to be extracted

### DIFF
--- a/src/utils/i18NextSrcParser.test.ts
+++ b/src/utils/i18NextSrcParser.test.ts
@@ -866,5 +866,97 @@ describe('getKeys', () => {
         },
       ]);
     });
+
+    it('extracts key from selector api', () => {
+      const content = 't(($) => $.a.b.c)';
+      expect(
+        getKeys(
+          'file.ts',
+          { typeMap: { CountType: { count: '' } }, parseGenerics: true },
+          content
+        )
+      ).toEqual([
+        {
+          key: 'a.b.c',
+        },
+      ]);
+    });
+
+    it('extracts key from selector api containing function body', () => {
+      const content = `t(function ($) {
+        return $.a.b.c;
+      })`;
+      expect(
+        getKeys(
+          'file.ts',
+          { typeMap: { CountType: { count: '' } }, parseGenerics: true },
+          content
+        )
+      ).toEqual([
+        {
+          key: 'a.b.c',
+        },
+      ]);
+    });
+
+    it('extracts key from selector api containing arrow function with body', () => {
+      const content = `t(($) => {
+        return $.a.b.c;
+      })`;
+      expect(
+        getKeys(
+          'file.ts',
+          { typeMap: { CountType: { count: '' } }, parseGenerics: true },
+          content
+        )
+      ).toEqual([
+        {
+          key: 'a.b.c',
+        },
+      ]);
+    });
+
+    it('extracts key and option from selector api', () => {
+      const content = 't(($) => $.a.b.c, { ns: "bar", keyPrefix: "" })';
+      expect(
+        getKeys(
+          'file.ts',
+          { typeMap: { CountType: { count: '' } }, parseGenerics: true },
+          content
+        )
+      ).toEqual([
+        {
+          key: 'a.b.c',
+          keyPrefix: '',
+          namespace: 'bar',
+          ns: 'bar',
+        },
+      ]);
+    });
+
+    it('extracts multiple nested keys from selector api', () => {
+      const content = `
+    t(($) => $.some.title);
+    t(($) => $.some.nested.title);
+    t(($) => $.some.nested.description);`;
+      expect(
+        getKeys(
+          'file.ts',
+          { typeMap: { CountType: { count: '' } }, parseGenerics: true },
+          content
+        )
+      ).toEqual([
+        {
+          key: 'some.title',
+        },
+        {
+          key: 'some.nested.title',
+        },
+
+        {
+          key: 'some.nested.description',
+        },
+      ]);
+    });
   });
 });

--- a/src/utils/i18NextSrcParser.ts
+++ b/src/utils/i18NextSrcParser.ts
@@ -473,6 +473,39 @@ const extractFromExpression = (node: ts.CallExpression, options: Options) => {
         return null;
       }
       entries[0].key = concatenatedString;
+    } else if (
+      ts.isFunctionExpression(keyArgument) ||
+      ts.isFunctionDeclaration(keyArgument) ||
+      ts.isArrowFunction(keyArgument)
+    ) {
+      // Try to find selector api definitions: ($) => $.a.b.c
+
+      if (!keyArgument.body) {
+        return null;
+      }
+
+      // Check if the function contains a return statement
+      if (ts.isBlock(keyArgument.body)) {
+        const returnStatement = keyArgument.body.statements.find((statement) =>
+          ts.isReturnStatement(statement)
+        );
+        if (
+          returnStatement &&
+          returnStatement.expression &&
+          ts.isPropertyAccessExpression(returnStatement.expression)
+        ) {
+          const [_, ...keys] = returnStatement.expression
+            .getFullText()
+            .split('.');
+
+          entries[0].key = keys.join('.');
+        } else {
+          return null;
+        }
+      } else {
+        const [_, ...keys] = keyArgument.body.getFullText().split('.');
+        entries[0].key = keys.join('.');
+      }
     } else {
       return null;
     }

--- a/translations/codeExamples/reacti18next/locales/en/translation.json
+++ b/translations/codeExamples/reacti18next/locales/en/translation.json
@@ -57,5 +57,12 @@
   "context_a": "context a",
   "context_b": "context_b",
   "context_c_one": "context_c_one",
-  "context_c_other": "context_c_other"
+  "context_c_other": "context_c_other",
+  "selector": {
+    "example": {
+      "one": "one",
+      "two": "two",
+      "three": "three"
+    }
+  }
 }

--- a/translations/codeExamples/reacti18next/locales/fr/translation.json
+++ b/translations/codeExamples/reacti18next/locales/fr/translation.json
@@ -57,5 +57,12 @@
   "context_a": "context a",
   "context_b": "context_b",
   "context_c_one": "context_c_one",
-  "context_c_other": "context_c_other"
+  "context_c_other": "context_c_other",
+  "selector": {
+    "example": {
+      "one": "one",
+      "two": "two",
+      "three": "three"
+    }
+  }
 }

--- a/translations/codeExamples/reacti18next/src/SelectorApiContent.tsx
+++ b/translations/codeExamples/reacti18next/src/SelectorApiContent.tsx
@@ -1,0 +1,25 @@
+// @ts-nocheck
+import React from 'react';
+import { useTranslation, Trans } from 'react-i18next';
+
+export const Content = () => {
+  const { t } = useTranslation();
+
+  return (
+    <p className="example">
+      <p>{t(($) => $.selector.example.one)}</p>
+
+      <p>
+        {t(function ($) {
+          return $.selector.example.two;
+        })}
+      </p>
+
+      <div>
+        {t(($) => {
+          return $.selector.example.three;
+        })}
+      </div>
+    </p>
+  );
+};


### PR DESCRIPTION
Enable to extract selector api defined keys in i18next.

```ts
t(($) => $.a.b.c);

t(function ($) {
  return $.a.b.c;
});

t(($) => {
  return $.a.b.c;
});

```

#112 