### PR TITLE
Add support for array element access in i18next selector api

### DIFF
--- a/src/utils/i18NextSrcParser.test.ts
+++ b/src/utils/i18NextSrcParser.test.ts
@@ -882,6 +882,21 @@ describe('getKeys', () => {
       ]);
     });
 
+    it('extracts key from selector api with array access', () => {
+      const content = 't(($) => $["a.b.c"])';
+      expect(
+        getKeys(
+          'file.ts',
+          { typeMap: { CountType: { count: '' } }, parseGenerics: true },
+          content
+        )
+      ).toEqual([
+        {
+          key: 'a.b.c',
+        },
+      ]);
+    });
+
     it('extracts key from selector api containing function body', () => {
       const content = `t(function ($) {
         return $.a.b.c;
@@ -899,9 +914,43 @@ describe('getKeys', () => {
       ]);
     });
 
+    it('extracts key from selector api with array access containing function body', () => {
+      const content = `t(function ($) {
+        return $["a.b.c"];
+      })`;
+      expect(
+        getKeys(
+          'file.ts',
+          { typeMap: { CountType: { count: '' } }, parseGenerics: true },
+          content
+        )
+      ).toEqual([
+        {
+          key: 'a.b.c',
+        },
+      ]);
+    });
+
     it('extracts key from selector api containing arrow function with body', () => {
       const content = `t(($) => {
         return $.a.b.c;
+      })`;
+      expect(
+        getKeys(
+          'file.ts',
+          { typeMap: { CountType: { count: '' } }, parseGenerics: true },
+          content
+        )
+      ).toEqual([
+        {
+          key: 'a.b.c',
+        },
+      ]);
+    });
+
+    it('extracts key from selector api with array access containing arrow function with body', () => {
+      const content = `t(($) => {
+        return $["a.b.c"];
       })`;
       expect(
         getKeys(
@@ -934,11 +983,30 @@ describe('getKeys', () => {
       ]);
     });
 
+    it('extracts key and option from selector api with array access', () => {
+      const content = 't(($) => $["a.b.c"], { ns: "bar", keyPrefix: "" })';
+      expect(
+        getKeys(
+          'file.ts',
+          { typeMap: { CountType: { count: '' } }, parseGenerics: true },
+          content
+        )
+      ).toEqual([
+        {
+          key: 'a.b.c',
+          keyPrefix: '',
+          namespace: 'bar',
+          ns: 'bar',
+        },
+      ]);
+    });
+
     it('extracts multiple nested keys from selector api', () => {
       const content = `
     t(($) => $.some.title);
     t(($) => $.some.nested.title);
-    t(($) => $.some.nested.description);`;
+    t(($) => $.some.nested.description);
+    t(($) => $['some.nested.content']);`;
       expect(
         getKeys(
           'file.ts',
@@ -955,6 +1023,9 @@ describe('getKeys', () => {
 
         {
           key: 'some.nested.description',
+        },
+        {
+          key: 'some.nested.content',
         },
       ]);
     });

--- a/src/utils/i18NextSrcParser.ts
+++ b/src/utils/i18NextSrcParser.ts
@@ -499,9 +499,26 @@ const extractFromExpression = (node: ts.CallExpression, options: Options) => {
             .split('.');
 
           entries[0].key = keys.join('.');
+        }
+        // check if the access is defined as an array.
+        // $["a.b.c"]
+        else if (
+          returnStatement &&
+          returnStatement.expression &&
+          ts.isElementAccessExpression(returnStatement.expression)
+        ) {
+          entries[0].key = returnStatement.expression.argumentExpression
+            .getFullText()
+            .replace(/['"]/g, '');
         } else {
           return null;
         }
+        // check if the access is defined as an array.
+        // $["a.b.c"]
+      } else if (ts.isElementAccessExpression(keyArgument.body)) {
+        entries[0].key = keyArgument.body.argumentExpression
+          .getFullText()
+          .replace(/['"]/g, '');
       } else {
         const [_, ...keys] = keyArgument.body.getFullText().split('.');
         entries[0].key = keys.join('.');

--- a/translations/codeExamples/reacti18next/locales/en/translation.json
+++ b/translations/codeExamples/reacti18next/locales/en/translation.json
@@ -62,7 +62,8 @@
     "example": {
       "one": "one",
       "two": "two",
-      "three": "three"
+      "three": "three",
+      "four": "four"
     }
   }
 }

--- a/translations/codeExamples/reacti18next/locales/fr/translation.json
+++ b/translations/codeExamples/reacti18next/locales/fr/translation.json
@@ -62,7 +62,8 @@
     "example": {
       "one": "one",
       "two": "two",
-      "three": "three"
+      "three": "three",
+      "four": "four"
     }
   }
 }

--- a/translations/codeExamples/reacti18next/src/SelectorApiContent.tsx
+++ b/translations/codeExamples/reacti18next/src/SelectorApiContent.tsx
@@ -20,6 +20,7 @@ export const Content = () => {
           return $.selector.example.three;
         })}
       </div>
+      <p>{t(($) => $['selector.example.four'])}</p>
     </p>
   );
 };


### PR DESCRIPTION
Supports using the i18next api selector with element access:

```ts
t($ => $["a.b.c"]);
```

#123 