### PR TITLE
Enable to define type alias in next-intl check

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,34 @@ yarn i18n:check --locales translations/i18NextMessageExamples -s en-US -f i18nex
 -u src --parser-component-functions WrappedTransComponent AnotherWrappedTransComponent
 ```
 
+### --next-intl-translation-fn-type-alias
+
+To find any indirect function calls inside a `next-intl` codebase, the parser will try to find the type `ReturnType<typeof useTranslations>` in the function call arguments.
+
+```ts
+const indirectFnCall = (
+  t: ReturnType<typeof useTranslations<'SomeNameSpace'>>
+) => {
+  const indirectTranslation = t('someKey');
+  // Do something with the indirectTranslation
+};
+```
+
+When a type alias is used instead of `ReturnType<typeof useTranslations>`, the `--next-intl-translation-fn-type-alias` option can be used to tell the parser the name of the type or types.
+
+```ts
+import { NextIntlTranslateFnAlias } from './types';
+
+const indirectFnCall = (t: NextIntlTranslateFnAlias<'SomeNameSpace'>) => {
+  const indirectTranslation = t('someKey');
+  // Do something with the indirectTranslation
+};
+```
+
+```bash
+yarn i18n:check --source en --locales translations/codeExamples/next-intl/locales/ -f next-intl -u translations/codeExamples/next-intl/src --next-intl-translation-fn-type-alias NextIntlTranslateFnAlias
+```
+
 ## Examples
 
 i18n-check is able to load and validate against different locale folder structures. Depending on how the locale files are organized, there are different configuration options.

--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -524,7 +524,7 @@ ${formatTable([
 
     it('should find unused and undefined keys for next-intl applications', async () => {
       const stdout = await execAsync(
-        'node dist/bin/index.js --source en --locales translations/codeExamples/next-intl/locales/ -f next-intl -u translations/codeExamples/next-intl/src'
+        'node dist/bin/index.js --source en --locales translations/codeExamples/next-intl/locales/ -f next-intl -u translations/codeExamples/next-intl/src --next-intl-translation-fn-type-alias NextIntlTranslateFnAlias NextIntlTranslateFnOtherAlias'
       );
 
       const result = stdout.split('Done')[0];
@@ -568,7 +568,7 @@ ${formatTable([
 
     it('should exit with code 0 when no unused keys are found', async () => {
       const cmd =
-        'node dist/bin/index.js --source en --locales translations/codeExamples/next-intl/locales/ -f next-intl -u translations/codeExamples/next-intl/src translations/codeExamples/next-intl/unused --only unused -i notUsedKey message.plural';
+        'node dist/bin/index.js --source en --locales translations/codeExamples/next-intl/locales/ -f next-intl -u translations/codeExamples/next-intl/src translations/codeExamples/next-intl/unused --only unused -i notUsedKey message.plural --next-intl-translation-fn-type-alias NextIntlTranslateFnAlias NextIntlTranslateFnOtherAlias';
 
       const result = await execAsyncWithExitCode(cmd);
 

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -65,6 +65,10 @@ program
     '--parser-component-functions <components...>',
     'a list of component names to parse when using the --unused option'
   )
+  .option(
+    '--next-intl-translation-fn-type-alias <nextIntlTranslationFnTypeAliases...>',
+    'next-intl translation function type aliases'
+  )
   .parse();
 
 const getCheckOptions = (): Context[] => {
@@ -107,6 +111,9 @@ const main = async () => {
   const ignore = program.getOptionValue('ignore');
   const unusedSrcPath = program.getOptionValue('unused');
   const componentFunctions = program.getOptionValue('parserComponentFunctions');
+  const nextIntlTranslationFnTypeAlias = program.getOptionValue(
+    'nextIntlTranslationFnTypeAlias'
+  );
 
   if (!srcPath) {
     console.log(
@@ -154,6 +161,7 @@ const main = async () => {
     checks: getCheckOptions(),
     format: format ?? undefined,
     ignore,
+    nextIntlTranslationFnTypeAlias,
   };
 
   const fileInfos: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,8 @@ export const checkUnusedKeys = async (
   } else if (options.format === 'next-intl') {
     return findUnusedNextIntlTranslations(
       filteredTranslationFiles,
-      filesToParse
+      filesToParse,
+      options
     );
   }
 };
@@ -212,11 +213,12 @@ const findUnusedI18NextTranslations = async (
 
 const findUnusedNextIntlTranslations = async (
   translationFiles: TranslationFile[],
-  filesToParse: string[]
+  filesToParse: string[],
+  options: Options
 ) => {
   const unusedKeys: Record<string, string[]> = {};
 
-  const extracted = nextIntlExtract(filesToParse);
+  const extracted = nextIntlExtract(filesToParse, options);
   const dynamicNamespaces = extracted.flatMap((namespace) => {
     if (namespace.meta.dynamic) {
       return [namespace.key];
@@ -386,7 +388,7 @@ const findUndefinedNextIntlKeys = async (
     })
   );
 
-  const extractedResult = nextIntlExtract(filesToParse);
+  const extractedResult = nextIntlExtract(filesToParse, options);
 
   const undefinedKeys: { [key: string]: string[] } = {};
   extractedResult.forEach(({ key, meta }) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,4 +23,5 @@ export type Options = {
   format?: 'icu' | 'i18next' | 'react-intl' | 'next-intl';
   checks?: Context[];
   ignore?: string[];
+  nextIntlTranslationFnTypeAlias?: string[];
 };

--- a/src/utils/nextIntlSrcParser.test.ts
+++ b/src/utils/nextIntlSrcParser.test.ts
@@ -25,6 +25,10 @@ const indirectFunctionCallExample = path.join(
   srcPath,
   'IndirectFunctionCalls.tsx'
 );
+const indirectFunctionCallWithTypeAliasExample = path.join(
+  srcPath,
+  'IndirectFunctionCallsWithTypeAlias.tsx'
+);
 
 describe('nextIntlSrcParser', () => {
   it('should find all the translation keys', () => {
@@ -709,6 +713,67 @@ describe('nextIntlSrcParser', () => {
         key: 'indirectNoNamespaceKeyTwo',
         meta: {
           file: indirectFunctionCallExample,
+          namespace: '',
+        },
+      },
+    ]);
+  });
+
+  it('should find all the keys that are used inside indirect function calls with type alias', () => {
+    const keys = extract([indirectFunctionCallWithTypeAliasExample], {
+      nextIntlTranslationFnTypeAlias: [
+        'NextIntlTranslateFnAlias',
+        'NextIntlTranslateFnOtherAlias',
+      ],
+    });
+
+    expect(keys).toEqual([
+      {
+        key: 'Basic.basic',
+        meta: {
+          file: indirectFunctionCallWithTypeAliasExample,
+          namespace: 'Basic',
+        },
+      },
+      {
+        key: 'Indirect5.indirect5',
+        meta: {
+          file: indirectFunctionCallWithTypeAliasExample,
+          namespace: 'Indirect5',
+        },
+      },
+      {
+        key: 'Indirect6.indirect6',
+        meta: {
+          file: indirectFunctionCallWithTypeAliasExample,
+          namespace: 'Indirect6',
+        },
+      },
+      {
+        key: 'Indirect7.indirect7',
+        meta: {
+          file: indirectFunctionCallWithTypeAliasExample,
+          namespace: 'Indirect7',
+        },
+      },
+      {
+        key: 'Indirect8.indirect8',
+        meta: {
+          file: indirectFunctionCallWithTypeAliasExample,
+          namespace: 'Indirect8',
+        },
+      },
+      {
+        key: 'indirectNoNamespaceKeyFour',
+        meta: {
+          file: indirectFunctionCallWithTypeAliasExample,
+          namespace: '',
+        },
+      },
+      {
+        key: 'indirectNoNamespaceKeyThree',
+        meta: {
+          file: indirectFunctionCallWithTypeAliasExample,
           namespace: '',
         },
       },

--- a/src/utils/nextIntlSrcParser.ts
+++ b/src/utils/nextIntlSrcParser.ts
@@ -1,18 +1,21 @@
 import fs from 'node:fs';
 import * as ts from 'typescript';
+import { Options } from '../types';
 
 const USE_TRANSLATIONS = 'useTranslations';
 const GET_TRANSLATIONS = 'getTranslations';
 const COMMENT_CONTAINS_STATIC_KEY_REGEX =
   /i18n-check t\((["'])(.*?[^\\])(["'])\)/;
 
-export const extract = (filesPaths: string[]) => {
-  return filesPaths.flatMap(getKeys).sort((a, b) => {
-    return a.key > b.key ? 1 : -1;
-  });
+export const extract = (filesPaths: string[], options: Options = {}) => {
+  return filesPaths
+    .flatMap((path) => getKeys(path, options))
+    .sort((a, b) => {
+      return a.key > b.key ? 1 : -1;
+    });
 };
 
-const getKeys = (path: string) => {
+const getKeys = (path: string, options?: Options) => {
   const content = fs.readFileSync(path, 'utf-8');
   const sourceFile = ts.createSourceFile(
     path,
@@ -353,6 +356,120 @@ const getKeys = (path: string) => {
             fnType.type.typeArguments[0].typeArguments &&
             fnType.type.typeArguments[0].typeArguments.length > 0
               ? fnType.type.typeArguments[0].typeArguments
+              : [];
+
+          if (fnType.name && ts.isIdentifier(fnType.name)) {
+            const name =
+              namespaceArgument &&
+              ts.isLiteralTypeNode(namespaceArgument) &&
+              ts.isStringLiteral(namespaceArgument.literal)
+                ? namespaceArgument.literal.text
+                : '';
+            pushNamespace({
+              name,
+              variable: fnType.name.text,
+            });
+          }
+        }
+      }
+
+      // Third scenaro is if t function the type is
+      // an alias for ReturnType<typeof useTranslations>
+      const tFunctionAliasParam =
+        node.parameters &&
+        node.parameters.find(
+          (param) =>
+            param.type &&
+            ts.isTypeReferenceNode(param.type) &&
+            param.type.typeName &&
+            ts.isIdentifier(param.type.typeName) &&
+            options &&
+            options.nextIntlTranslationFnTypeAlias !== undefined &&
+            options?.nextIntlTranslationFnTypeAlias.includes(
+              param.type.typeName.text
+            )
+        );
+
+      if (
+        tFunctionAliasParam !== undefined &&
+        tFunctionAliasParam.type &&
+        ts.isTypeReferenceNode(tFunctionAliasParam.type)
+      ) {
+        const [namespaceArgument] =
+          tFunctionAliasParam.type.typeArguments &&
+          tFunctionAliasParam.type.typeArguments.length > 0
+            ? tFunctionAliasParam.type.typeArguments
+            : [];
+
+        if (ts.isIdentifier(tFunctionAliasParam.name)) {
+          const name =
+            namespaceArgument &&
+            ts.isLiteralTypeNode(namespaceArgument) &&
+            ts.isStringLiteral(namespaceArgument.literal)
+              ? namespaceArgument.literal.text
+              : '';
+          pushNamespace({
+            name,
+            variable: tFunctionAliasParam.name.text,
+          });
+        }
+      }
+
+      // Fourth scenario is the t function is defined as an object property and uses an alias:
+      // someFn({t}: {t: AliasForTheOriginalNextIntlType}>
+      const tFunctionParamAliasAsProperty =
+        node.parameters &&
+        node.parameters.find(
+          (param) =>
+            param.type &&
+            ts.isTypeLiteralNode(param.type) &&
+            param.type.members.find((member) => {
+              return (
+                ts.isPropertySignature(member) &&
+                member.type &&
+                ts.isTypeReferenceNode(member.type) &&
+                member.type.typeName &&
+                ts.isIdentifier(member.type.typeName) &&
+                options &&
+                options.nextIntlTranslationFnTypeAlias !== undefined &&
+                options?.nextIntlTranslationFnTypeAlias.includes(
+                  member.type.typeName.text
+                )
+              );
+            })
+        );
+
+      if (
+        tFunctionParamAliasAsProperty !== undefined &&
+        tFunctionParamAliasAsProperty.type &&
+        ts.isTypeLiteralNode(tFunctionParamAliasAsProperty.type)
+      ) {
+        const fnType = tFunctionParamAliasAsProperty.type.members.find(
+          (member) => {
+            return (
+              ts.isPropertySignature(member) &&
+              member.type &&
+              ts.isTypeReferenceNode(member.type) &&
+              member.type.typeName &&
+              ts.isIdentifier(member.type.typeName) &&
+              options &&
+              options.nextIntlTranslationFnTypeAlias !== undefined &&
+              options?.nextIntlTranslationFnTypeAlias.includes(
+                member.type.typeName.text
+              )
+            );
+          }
+        );
+
+        if (
+          fnType &&
+          ts.isPropertySignature(fnType) &&
+          fnType.type &&
+          ts.isTypeReferenceNode(fnType.type)
+        ) {
+          const [namespaceArgument] =
+            fnType.type.typeArguments && fnType.type.typeArguments.length > 0
+              ? fnType.type.typeArguments
               : [];
 
           if (fnType.name && ts.isIdentifier(fnType.name)) {

--- a/translations/codeExamples/next-intl/locales/en/translation.json
+++ b/translations/codeExamples/next-intl/locales/en/translation.json
@@ -168,6 +168,20 @@
   "Indirect4": {
     "indirect4": "indirect4"
   },
+  "Indirect5": {
+    "indirect5": "indirect5"
+  },
+  "Indirect6": {
+    "indirect6": "indirect6"
+  },
+  "Indirect7": {
+    "indirect7": "indirect7"
+  },
+  "Indirect8": {
+    "indirect8": "indirect8"
+  },
   "indirectNoNamespaceKeyOne": "indirectNoNamespaceKeyOne",
-  "indirectNoNamespaceKeyTwo": "indirectNoNamespaceKeyTwo"
+  "indirectNoNamespaceKeyTwo": "indirectNoNamespaceKeyTwo",
+  "indirectNoNamespaceKeyThree": "indirectNoNamespaceKeyThree",
+  "indirectNoNamespaceKeyFour": "indirectNoNamespaceKeyFour"
 }

--- a/translations/codeExamples/next-intl/locales/fr/translation.json
+++ b/translations/codeExamples/next-intl/locales/fr/translation.json
@@ -165,9 +165,23 @@
   "Indirect3": {
     "indirect3": "indirect3"
   },
+  "Indirect5": {
+    "indirect5": "indirect5"
+  },
+  "Indirect6": {
+    "indirect6": "indirect6"
+  },
+  "Indirect7": {
+    "indirect7": "indirect7"
+  },
+  "Indirect8": {
+    "indirect8": "indirect8"
+  },
   "Indirect4": {
     "indirect4": "indirect4"
   },
   "indirectNoNamespaceKeyOne": "indirectNoNamespaceKeyOne",
-  "indirectNoNamespaceKeyTwo": "indirectNoNamespaceKeyTwo"
+  "indirectNoNamespaceKeyTwo": "indirectNoNamespaceKeyTwo",
+  "indirectNoNamespaceKeyThree": "indirectNoNamespaceKeyThree",
+  "indirectNoNamespaceKeyFour": "indirectNoNamespaceKeyFour"
 }

--- a/translations/codeExamples/next-intl/src/IndirectFunctionCallsWithTypeAlias.tsx
+++ b/translations/codeExamples/next-intl/src/IndirectFunctionCallsWithTypeAlias.tsx
@@ -1,0 +1,75 @@
+// @ts-nocheck
+import { useTranslations, _Translator } from 'next-intl';
+import * as z from 'zod';
+import { NextIntlTranslateFnAlias } from './types';
+import { NextIntlTranslateFnOtherAlias } from './types';
+
+export default function IndirectFunctionCallsExample() {
+  const indirectFnCall = (t: NextIntlTranslateFnAlias<'Indirect5'>) => {
+    const indirectTranslation = t('indirect5');
+    // Do something with the indirectTranslation
+  };
+
+  const indirectT1 = useTranslations('Indirect5');
+  indirectFnCall(indirectT1);
+
+  const indirectFnCallWithMultipleParameters = (
+    id: string,
+    otherT: NextIntlTranslateFnOtherAlias<'Indirect6'>
+  ) => {
+    const indirectTranslation = otherT('indirect6');
+    // Do something with the indirectTranslation
+  };
+
+  const indirectT2 = useTranslations('Indirect6');
+  indirectFnCallWithMultipleParameters(indirectT2);
+
+  const indirectFnWithTAsObjectPropertyCall = (
+    someProperty: string,
+    {
+      t,
+    }: {
+      t: NextIntlTranslateFnAlias<'Indirect7'>;
+    }
+  ) => {
+    const indirectTranslation = t('indirect7');
+    // Do something with the indirectTranslation
+  };
+
+  const indirectT3 = useTranslations('Indirect7');
+  indirectFnWithTAsObjectPropertyCall(indirectT3);
+
+  const indirectFnCallWithNoNamespace = (
+    id: string,
+    otherT: NextIntlTranslateFnAlias
+  ) => {
+    const indirectTranslation = otherT('indirectNoNamespaceKeyThree');
+    // Do something with the indirectTranslation
+  };
+
+  indirectFnCallWithNoNamespace(useTranslations());
+
+  const indirectFnWithTAsObjectPropertyCallWithNoNamespace = (
+    someProperty: string,
+    {
+      t,
+    }: {
+      t: NextIntlTranslateFnAlias;
+    }
+  ) => {
+    const indirectTranslation = t('indirectNoNamespaceKeyFour');
+    // Do something with the indirectTranslation
+  };
+
+  const indirectT4 = useTranslations();
+  indirectFnWithTAsObjectPropertyCall(indirectT4);
+
+  const someSchema = (t: NextIntlTranslateFnOtherAlias<'Indirect8'>) =>
+    z.string().min(5, t('indirect8'));
+
+  someSchema(useTranslations('Indirect8'));
+
+  const t = useTranslations('Basic');
+
+  return <div>{t('basic')}</div>;
+}


### PR DESCRIPTION
Adds the option to define `next-intl` type aliases when indirect function calls use a type alias instead of the built in type.
Introduces the option `--next-intl-translation-fn-type-alias` to define all the used type aliases.

```ts
import { NextIntlTranslateFnAlias } from './types';

const indirectFnCall = (t: NextIntlTranslateFnAlias<'SomeNameSpace'>) => {
  // use the t function...
};
```

Enables to pass multiple type aliases:

```bash
--next-intl-translation-fn-type-alias NextIntlTranslateFnAlias NextIntlTranslateFnOtherAlias
```

#122 