### PR TITLE
chore(deps): bump chalk, commander and @formatjs/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ yarn-error.log*
 yarn.lock
 
 .DS_Store
+
+mise.local.toml

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "!dist/**/*.test.*"
   ],
   "dependencies": {
-    "@formatjs/cli-lib": "^8.5.1",
-    "@formatjs/icu-messageformat-parser": "^2.11.4",
+    "@formatjs/cli-lib": "^8.5.4",
+    "@formatjs/icu-messageformat-parser": "^3.5.6",
     "chalk": "^5.6.2",
     "commander": "^14.0.3",
     "glob": "^13.0.6",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@formatjs/cli-lib": "^8.5.1",
     "@formatjs/icu-messageformat-parser": "^2.11.4",
-    "chalk": "^4.1.2",
-    "commander": "^12.1.0",
+    "chalk": "^5.6.2",
+    "commander": "^14.0.3",
     "glob": "^13.0.6",
     "typescript": "^5.9.3",
     "yaml": "^2.8.3"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.3",
   "description": "i18n translation messages check",
   "license": "MIT",
+  "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: ^2.11.4
         version: 2.11.4
       chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
+        specifier: ^5.6.2
+        version: 5.6.2
       commander:
-        specifier: ^12.1.0
-        version: 12.1.0
+        specifier: ^14.0.3
+        version: 14.0.3
       glob:
         specifier: ^13.0.6
         version: 13.0.6
@@ -609,10 +609,6 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
-
   array-find-index@1.0.2:
     resolution: {integrity: sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==}
     engines: {node: '>=0.10.0'}
@@ -649,20 +645,9 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
-  chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
-
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  commander@12.1.0:
-    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
-    engines: {node: '>=18'}
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -861,10 +846,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
 
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
@@ -1088,10 +1069,6 @@ packages:
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
-
-  supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1694,10 +1671,6 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
-
   array-find-index@1.0.2: {}
 
   assertion-error@2.0.1: {}
@@ -1731,18 +1704,7 @@ snapshots:
 
   chai@6.2.2: {}
 
-  chalk@4.1.2:
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
-
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
-
-  commander@12.1.0: {}
+  chalk@5.6.2: {}
 
   commander@14.0.3: {}
 
@@ -1980,8 +1942,6 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  has-flag@4.0.0: {}
-
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
@@ -2192,10 +2152,6 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@4.1.0: {}
-
-  supports-color@7.2.0:
-    dependencies:
-      has-flag: 4.0.0
 
   tinybench@2.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@formatjs/cli-lib':
-        specifier: ^8.5.1
-        version: 8.5.2
+        specifier: ^8.5.4
+        version: 8.5.4
       '@formatjs/icu-messageformat-parser':
-        specifier: ^2.11.4
-        version: 2.11.4
+        specifier: ^3.5.6
+        version: 3.5.6
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -252,8 +252,8 @@ packages:
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@formatjs/cli-lib@8.5.2':
-    resolution: {integrity: sha512-pOWmeL6ypayHyf41eVVzZtC2h4L+z+3KbP5THEAcImc4NUxPiJcIikU12rlBChXHUEv9CBMWQ0rY6qMTHNUyXA==}
+  '@formatjs/cli-lib@8.5.4':
+    resolution: {integrity: sha512-h+0AXA/nYLSL9xWvG+DJQTjTAQDYQq89zky9hUuROw6jy/Te0Mwgsrn6/xFvdXootTB8DLp9mpFA2mNXLtgpxA==}
     engines: {node: '>= 20.12.0'}
     peerDependencies:
       '@glimmer/env': '*'
@@ -282,29 +282,14 @@ packages:
       vue:
         optional: true
 
-  '@formatjs/ecma402-abstract@2.3.6':
-    resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
+  '@formatjs/icu-messageformat-parser@3.5.6':
+    resolution: {integrity: sha512-04ZjRIeQCnR/h32wBP9/S7rkyy1hLAs2fXJcNwc7hseJd//K9TMBqK0ukb4dXqnALKQ9m5ruZeOD2qqEkK9ixg==}
 
-  '@formatjs/fast-memoize@2.2.7':
-    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
+  '@formatjs/icu-skeleton-parser@2.1.6':
+    resolution: {integrity: sha512-9f1VQ2kaaLHK0WPU1OrAmiNKCKJwyoDmwNzQXbUa6XtFBOgHZ4YZURE8sSedHmMr0kvpB75OtplB0hMYkfdwfg==}
 
-  '@formatjs/icu-messageformat-parser@2.11.4':
-    resolution: {integrity: sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==}
-
-  '@formatjs/icu-messageformat-parser@3.5.4':
-    resolution: {integrity: sha512-JVY39ROgLt+pIYngo6piyj4OVfZmXs/2FkC4wLS+ql1Eig/sGJKB7YwDO/5bkJFkfwaFAeIpgEiJc8hiYxNalw==}
-
-  '@formatjs/icu-skeleton-parser@1.8.16':
-    resolution: {integrity: sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==}
-
-  '@formatjs/icu-skeleton-parser@2.1.4':
-    resolution: {integrity: sha512-8bSFZbrlvGX11ywMZxtgkPBt5Q8/etyts7j7j+GWpOVK1g43zwMIH3LZxk43HAtEP7L/jtZ+OZaMiFTOiBj9CA==}
-
-  '@formatjs/intl-localematcher@0.6.2':
-    resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
-
-  '@formatjs/ts-transformer@4.4.4':
-    resolution: {integrity: sha512-z4gfvsw8iw/XN+X9SgBtehMdtpZHB4Yreic1GdOV6F3A9N7uTqtRaUgHb4QPaQOP7hXqXyO1/7JqlD86mb4VXQ==}
+  '@formatjs/ts-transformer@4.4.6':
+    resolution: {integrity: sha512-XL+8x5yWtPUm4HTMPcaHYaXoQvB8eFgAy4fIPA0GpKStK3NA2l4Yx05PINaIzOzyeN2yIjIXPxYqMkqtORcj5w==}
     engines: {node: '>= 20.12.0'}
     peerDependencies:
       ts-jest: ^29
@@ -673,9 +658,6 @@ packages:
       supports-color:
         optional: true
 
-  decimal.js@10.6.0:
-    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
-
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -952,8 +934,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1005,8 +987,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1094,9 +1076,6 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
-
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -1342,11 +1321,11 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@formatjs/cli-lib@8.5.2':
+  '@formatjs/cli-lib@8.5.4':
     dependencies:
-      '@formatjs/icu-messageformat-parser': 3.5.4
-      '@formatjs/icu-skeleton-parser': 2.1.4
-      '@formatjs/ts-transformer': 4.4.4
+      '@formatjs/icu-messageformat-parser': 3.5.6
+      '@formatjs/icu-skeleton-parser': 2.1.6
+      '@formatjs/ts-transformer': 4.4.6
       '@types/estree': 1.0.8
       '@types/fs-extra': 11.0.4
       '@types/node': 22.19.17
@@ -1359,41 +1338,15 @@ snapshots:
     transitivePeerDependencies:
       - ts-jest
 
-  '@formatjs/ecma402-abstract@2.3.6':
+  '@formatjs/icu-messageformat-parser@3.5.6':
     dependencies:
-      '@formatjs/fast-memoize': 2.2.7
-      '@formatjs/intl-localematcher': 0.6.2
-      decimal.js: 10.6.0
-      tslib: 2.8.1
+      '@formatjs/icu-skeleton-parser': 2.1.6
 
-  '@formatjs/fast-memoize@2.2.7':
+  '@formatjs/icu-skeleton-parser@2.1.6': {}
+
+  '@formatjs/ts-transformer@4.4.6':
     dependencies:
-      tslib: 2.8.1
-
-  '@formatjs/icu-messageformat-parser@2.11.4':
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.3.6
-      '@formatjs/icu-skeleton-parser': 1.8.16
-      tslib: 2.8.1
-
-  '@formatjs/icu-messageformat-parser@3.5.4':
-    dependencies:
-      '@formatjs/icu-skeleton-parser': 2.1.4
-
-  '@formatjs/icu-skeleton-parser@1.8.16':
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.3.6
-      tslib: 2.8.1
-
-  '@formatjs/icu-skeleton-parser@2.1.4': {}
-
-  '@formatjs/intl-localematcher@0.6.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@formatjs/ts-transformer@4.4.4':
-    dependencies:
-      '@formatjs/icu-messageformat-parser': 3.5.4
+      '@formatjs/icu-messageformat-parser': 3.5.6
       '@types/node': 22.19.17
       json-stable-stringify: 1.3.0
       typescript: 5.9.3
@@ -1724,8 +1677,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decimal.js@10.6.0: {}
-
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -2033,7 +1984,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
 
@@ -2075,9 +2026,9 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.10:
+  postcss@8.5.13:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2172,8 +2123,6 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  tslib@2.8.1: {}
-
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -2204,7 +2153,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.10
+      postcss: 8.5.13
       rollup: 4.60.2
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -1,7 +1,7 @@
 import { exec } from 'child_process';
 import path from 'path';
 import { describe, it, expect } from 'vitest';
-import { formatTable } from '../errorReporters';
+import { formatTable } from '../errorReporters.js';
 
 function tr(file: string) {
   return path.join('translations', file);

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -6,25 +6,33 @@ import chalk from 'chalk';
 import { program } from 'commander';
 import { glob, globSync } from 'glob';
 import { parse } from 'yaml';
-import { checkTranslations, checkUndefinedKeys, checkUnusedKeys } from '..';
+import {
+  checkTranslations,
+  checkUndefinedKeys,
+  checkUnusedKeys,
+} from '../index.js';
 import {
   CheckOptions,
   Context,
   formatCheckResultTable,
   formatInvalidTranslationsResultTable,
   formatSummaryTable,
-} from '../errorReporters';
+} from '../errorReporters.js';
 import {
   CheckResult,
   FileInfo,
   InvalidTranslationsResult,
   TranslationFile,
-} from '../types';
-import { flattenTranslations } from '../utils/flattenTranslations';
+} from '../types.js';
+import { flattenTranslations } from '../utils/flattenTranslations.js';
 import path from 'node:path';
-import { CheckError } from '../utils/findInvalidTranslations';
+import { createRequire } from 'node:module';
+import { CheckError } from '../utils/findInvalidTranslations.js';
 
-const version = require('../../package.json').version;
+// Use createRequire because JSON imports differ across Node.js 20 versions
+// (`assert` vs `with`) and TypeScript can't handle both reliably
+const require = createRequire(import.meta.url);
+const { version } = require('../../package.json');
 
 program
   .version(version)

--- a/src/errorReporters.test.ts
+++ b/src/errorReporters.test.ts
@@ -4,7 +4,7 @@ import {
   formatInvalidTranslationsResultTable,
   formatSummaryTable,
   formatTable,
-} from './errorReporters';
+} from './errorReporters.js';
 
 describe('formatTable', () => {
   test('single col and row', () => {

--- a/src/errorReporters.ts
+++ b/src/errorReporters.ts
@@ -1,4 +1,4 @@
-import { CheckResult, InvalidTranslationsResult } from './types';
+import { CheckResult, InvalidTranslationsResult } from './types.js';
 
 export type StandardReporter = {
   file: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,18 @@
-import { findMissingKeys } from './utils/findMissingKeys';
+import { findMissingKeys } from './utils/findMissingKeys.js';
 import {
   CheckResult,
   InvalidTranslationsResult,
   Options,
   Translation,
   TranslationFile,
-} from './types';
-import { findInvalidTranslations } from './utils/findInvalidTranslations';
-import { findInvalidI18NextTranslations } from './utils/findInvalidI18NextTranslations';
-import { getKeys } from './utils/i18NextSrcParser';
-import { extract as nextIntlExtract } from './utils/nextIntlSrcParser';
+} from './types.js';
+import { findInvalidTranslations } from './utils/findInvalidTranslations.js';
+import { findInvalidI18NextTranslations } from './utils/findInvalidI18NextTranslations.js';
+import { getKeys } from './utils/i18NextSrcParser.js';
+import { extract as nextIntlExtract } from './utils/nextIntlSrcParser.js';
 import fs from 'fs';
 import path from 'path';
-import { I18NEXT_PLURAL_SUFFIX } from './utils/constants';
+import { I18NEXT_PLURAL_SUFFIX } from './utils/constants.js';
 
 const ParseFormats = ['react-intl', 'i18next', 'next-intl'];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Context } from './errorReporters';
+import { Context } from './errorReporters.js';
 
 export type Translation = Record<string, unknown>;
 

--- a/src/utils/findInvalidI18NextTranslations.test.ts
+++ b/src/utils/findInvalidI18NextTranslations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   compareTranslationFiles,
   findInvalidI18NextTranslations,
-} from './findInvalidI18NextTranslations';
-import { flattenTranslations } from './flattenTranslations';
+} from './findInvalidI18NextTranslations.js';
+import { flattenTranslations } from './flattenTranslations.js';
 
 const sourceFile = require('../../translations/i18NextMessageExamples/en-us.json');
 const targetFile = require('../../translations/i18NextMessageExamples/de-de.json');

--- a/src/utils/findInvalidI18NextTranslations.ts
+++ b/src/utils/findInvalidI18NextTranslations.ts
@@ -5,12 +5,12 @@
  *
  */
 
-import { parse, MessageFormatElement } from './i18NextParser';
+import { parse, MessageFormatElement } from './i18NextParser.js';
 import {
   InvalidTranslationEntry,
   InvalidTranslationsResult,
   Translation,
-} from '../types';
+} from '../types.js';
 
 export const findInvalidI18NextTranslations = (
   source: Translation,

--- a/src/utils/findInvalidTranslations.test.ts
+++ b/src/utils/findInvalidTranslations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   compareTranslationFiles,
   findInvalidTranslations,
-} from './findInvalidTranslations';
-import { flattenTranslations } from './flattenTranslations';
+} from './findInvalidTranslations.js';
+import { flattenTranslations } from './flattenTranslations.js';
 
 const sourceFile = require('../../translations/messageExamples/en-us.json');
 const secondaryFile = require('../../translations/messageExamples/de-de.json');

--- a/src/utils/findInvalidTranslations.ts
+++ b/src/utils/findInvalidTranslations.ts
@@ -11,7 +11,7 @@ import {
   InvalidTranslationEntry,
   InvalidTranslationsResult,
   Translation,
-} from '../types';
+} from '../types.js';
 
 type Location = { start: { line: number; column: number } };
 

--- a/src/utils/findMissingKeys.test.ts
+++ b/src/utils/findMissingKeys.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { compareTranslationFiles, findMissingKeys } from './findMissingKeys';
+import { compareTranslationFiles, findMissingKeys } from './findMissingKeys.js';
 
 const sourceFile = {
   'one.two.three': 'one two three',

--- a/src/utils/findMissingKeys.ts
+++ b/src/utils/findMissingKeys.ts
@@ -1,5 +1,5 @@
-import { Options, Translation } from '../types';
-import { I18NEXT_PLURAL_SUFFIX } from './constants';
+import { Options, Translation } from '../types.js';
+import { I18NEXT_PLURAL_SUFFIX } from './constants.js';
 
 export const findMissingKeys = (
   source: Translation,

--- a/src/utils/flattenTranslations.test.ts
+++ b/src/utils/flattenTranslations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { flattenEntry, flattenTranslations } from './flattenTranslations';
+import { flattenEntry, flattenTranslations } from './flattenTranslations.js';
 
 const flatStructure = require('../../translations/en-us.json');
 const nestedStructure = require('../../translations/flattenExamples/en-us.json');

--- a/src/utils/flattenTranslations.ts
+++ b/src/utils/flattenTranslations.ts
@@ -1,4 +1,4 @@
-import { Translation } from '../types';
+import { Translation } from '../types.js';
 
 export const flattenTranslations = (translations: Translation) => {
   if (!hasNestedDefinitions(translations)) {

--- a/src/utils/i18NextParser.test.ts
+++ b/src/utils/i18NextParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parse } from './i18NextParser';
+import { parse } from './i18NextParser.js';
 
 describe('i18NextParser', () => {
   it('should parse interpolation', () => {

--- a/src/utils/i18NextSrcParser.test.ts
+++ b/src/utils/i18NextSrcParser.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { getKeys } from './i18NextSrcParser';
+import { getKeys } from './i18NextSrcParser.js';
 
 describe('getKeys', () => {
   describe('supports JSX', () => {

--- a/src/utils/nextIntlSrcParser.test.ts
+++ b/src/utils/nextIntlSrcParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extract } from './nextIntlSrcParser';
+import { extract } from './nextIntlSrcParser.js';
 import path from 'node:path';
 
 const srcPath = './translations/codeExamples/next-intl/src/';

--- a/src/utils/nextIntlSrcParser.ts
+++ b/src/utils/nextIntlSrcParser.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import * as ts from 'typescript';
-import { Options } from '../types';
+import { Options } from '../types.js';
 
 const USE_TRANSLATIONS = 'useTranslations';
 const GET_TRANSLATIONS = 'getTranslations';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,113 +1,18 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
-
-    /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
-    /* Language and Environment */
-    "target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
-    /* Modules */
-    "module": "NodeNext" /* Specify what module code is generated. */,
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    "types": [
-      "node",
-      "vitest"
-    ] /* Specify type package names to be included without being referenced in a source file. */,
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
-    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
-    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
-    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
-    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
-    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
-    /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
-    /* Emit */
-    "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
-    /* Interop Constraints */
-    "isolatedModules": true /* Ensure that each file can be safely transpiled without relying on other imports. */,
-    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-
-    /* Type Checking */
-    "strict": true /* Enable all strict type-checking options. */,
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
-    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    "target": "es2021",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["node", "vitest"],
+    "declaration": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Sorry, in the commit from the previous PR, the `chalk` and `commander` versions weren't updated; I must have accidentally deleted them while resolving a merge conflict when I was fixing the `test-cli` job failure.

Updating `chalk`, `commander`, `@formatjs/cli-lib` and `@formatjs/icu-messageformat-parser` results in slightly fewer dependencies due to `commander` and `@formatjs/icu-messageformat-parser` being reused by `formatjs/cli-lib@8.5.3` and the fact that `chalk` v5 has no dependencies. As a result, there are now 13 fewer dependencies (73 vs. 86).

[Old graph](https://npmgraph.js.org/?q=https://github.com/nakrovati/i18n-check/blob/main/package.json) / [New graph](https://npmgraph.js.org/?q=https://github.com/nakrovati/i18n-check/blob/chore/bump-deps/package.json)