### PR TITLE
Fix i18next selector api formatted element access

### DIFF
--- a/src/utils/i18NextSrcParser.test.ts
+++ b/src/utils/i18NextSrcParser.test.ts
@@ -897,6 +897,23 @@ describe('getKeys', () => {
       ]);
     });
 
+    it('extracts key from selector api with multi-line array access', () => {
+      const content = `t(($) => $[
+        "a.b.c"
+      ])`;
+      expect(
+        getKeys(
+          'file.ts',
+          { typeMap: { CountType: { count: '' } }, parseGenerics: true },
+          content
+        )
+      ).toEqual([
+        {
+          key: 'a.b.c',
+        },
+      ]);
+    });
+
     it('extracts key from selector api containing function body', () => {
       const content = `t(function ($) {
         return $.a.b.c;
@@ -917,6 +934,25 @@ describe('getKeys', () => {
     it('extracts key from selector api with array access containing function body', () => {
       const content = `t(function ($) {
         return $["a.b.c"];
+      })`;
+      expect(
+        getKeys(
+          'file.ts',
+          { typeMap: { CountType: { count: '' } }, parseGenerics: true },
+          content
+        )
+      ).toEqual([
+        {
+          key: 'a.b.c',
+        },
+      ]);
+    });
+
+    it('extracts key from selector api with multi-line array access containing function body', () => {
+      const content = `t(function ($) {
+        return $[
+          "a.b.c"
+        ];
       })`;
       expect(
         getKeys(

--- a/src/utils/i18NextSrcParser.ts
+++ b/src/utils/i18NextSrcParser.ts
@@ -509,7 +509,8 @@ const extractFromExpression = (node: ts.CallExpression, options: Options) => {
         ) {
           entries[0].key = returnStatement.expression.argumentExpression
             .getFullText()
-            .replace(/['"]/g, '');
+            .replace(/['"]/g, '')
+            .trim();
         } else {
           return null;
         }
@@ -518,7 +519,8 @@ const extractFromExpression = (node: ts.CallExpression, options: Options) => {
       } else if (ts.isElementAccessExpression(keyArgument.body)) {
         entries[0].key = keyArgument.body.argumentExpression
           .getFullText()
-          .replace(/['"]/g, '');
+          .replace(/['"]/g, '')
+          .trim();
       } else {
         const [_, ...keys] = keyArgument.body.getFullText().split('.');
         entries[0].key = keys.join('.');


### PR DESCRIPTION
Fixes array element access in i18next selector api when formatted:

```ts
t(($) => $[
  "a.b.c"
])
```

The key `a.b.c` can now be found by the parser as previously it would not be correctly extracted.

#123 