### PR TITLE
Bump PNPM to 10.34.4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,14 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
 
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
+
       - name: Install dependencies and build
         run: pnpm install --frozen-lockfile && pnpm run build
+
       - name: Publish package to NPM
         run: npm publish --access public

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,9 +1,13 @@
 name: Test
+
 on:
-  pull_request:
   push:
     branches:
       - main
+  pull_request:
+
+env:
+  NODE_VERSION: 20
 
 jobs:
   lint:
@@ -11,12 +15,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
-          cache: 'pnpm'
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: pnpm install & lint
         run: |
           pnpm install --frozen-lockfile
@@ -31,12 +37,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
-          cache: 'pnpm'
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: pnpm install & test
         run: |
           pnpm install --frozen-lockfile
@@ -51,12 +59,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
-          cache: 'pnpm'
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: pnpm install & test
         run: |
           pnpm install --frozen-lockfile
@@ -71,12 +81,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
-          cache: 'pnpm'
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: pnpm install & build
         run: |

--- a/package.json
+++ b/package.json
@@ -50,5 +50,5 @@
   "engines": {
     "node": ">=20"
   },
-  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264"
+  "packageManager": "pnpm@10.34.4+sha512.8768be55200ae3f2226b6527fcca2687e14bc4e5f12d7721a0f25da3df47915177058648db4177baf348120fa0ba2752d8d8d93f6beaf1fe64ae18da8de961af"
 }


### PR DESCRIPTION
1. Update PNPM to version 10.34.4 - several [vulnerabilities](https://github.com/pnpm/pnpm/security) have recently been discovered in PNPM versions earlier than 10.34.1.
2. Use `cache: true` in `pnpm/action-setup` to enable caching.
3. Specify the Node.js version in `env.NODE_VERSION`